### PR TITLE
Update link for Octopets Memory Leak Sample

### DIFF
--- a/samples/automation/sample-apps/octopets-setup.md
+++ b/samples/automation/sample-apps/octopets-setup.md
@@ -105,7 +105,7 @@ git push myrepo main
 Now that your Octopets application is deployed and configured:
 
 1. Follow the [Configure SRE Agent Guide](../00-configure-sre-agent.md) to set up Azure SRE Agent with incident platform, Outlook, and GitHub connectors
-2. Then proceed to the [Octopets Memory Leak Sample](../01-octopets-memleak-sample.md) to test incident automation
+2. Then proceed to the [Octopets Memory Leak Sample](../samples/01-incident-automation-sample.md) to test incident automation
 
 ## Resources
 


### PR DESCRIPTION
This pull request updates a documentation link in the Octopets setup guide to point to the correct location for the incident automation sample.

- Documentation update:
  * Updated the link to the "Octopets Memory Leak Sample" in `octopets-setup.md` to reference the correct path: `../samples/01-incident-automation-sample.md`.