### PR TITLE
Add hands-on lab sample: 3-persona SRE Agent lab with azd up

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -10,18 +10,25 @@ samples/
 │   ├── bicep/
 │   ├── examples/
 │   └── scripts/
-└── automation/                # Automation samples with configuration guides and sample apps
-    ├── configuration/
-    │   └── 00-configure-sre-agent.md
-    ├── samples/
-    │   ├── 01-incident-automation-sample.md
-    │   └── 02-scheduled-health-check-sample.md
-    ├── sample-apps/
-    │   └── octopets-setup.md
-    ├── subagents/
-    │   ├── pd-azure-resource-error-handler.yaml
-    │   └── health-check-agent.yaml
-    └── images/
+├── automation/                # Automation samples with configuration guides and sample apps
+│   ├── configuration/
+│   │   └── 00-configure-sre-agent.md
+│   ├── samples/
+│   │   ├── 01-incident-automation-sample.md
+│   │   └── 02-scheduled-health-check-sample.md
+│   ├── sample-apps/
+│   │   └── octopets-setup.md
+│   ├── subagents/
+│   │   ├── pd-azure-resource-error-handler.yaml
+│   │   └── health-check-agent.yaml
+│   └── images/
+└── hands-on-lab/              # Complete hands-on lab with 3 personas (azd up)
+    ├── azure.yaml
+    ├── infra/                 # Bicep templates
+    ├── scripts/               # Post-provision, break-app, sample issues
+    ├── sre-config/            # Subagent YAML specs
+    ├── knowledge-base/        # Runbooks and incident templates
+    └── lab/                   # Skillable lab instructions
 ```
 
 ## Available Samples
@@ -39,6 +46,20 @@ Complete guide for setting up automated incident response with Azure SRE Agent, 
 2. Configure SRE Agent: [00-configure-sre-agent.md](./automation/configuration/00-configure-sre-agent.md)
 3. Test incident automation: [01-octopets-memleak-sample.md](./automation/samples/01-incident-automation-sample.md)
 4. Review subagent example: [pd-azure-resource-error-handler.yaml](./automation/subagents/pd-azure-resource-error-handler.yaml)
+
+### 3. Hands-On Lab (Grubify)
+Complete hands-on lab deployable with a single `azd up` command. Covers 3 personas:
+
+| Persona | What You'll See |
+|---------|----------------|
+| **IT Operations** | Autonomous incident detection, log analysis, KB-driven investigation, remediation |
+| **Developer** | Source code root cause analysis with file:line references, structured GitHub issues |
+| **Workflow Automation** | Automated issue triage via scheduled tasks, label + comment on customer issues |
+
+**Get Started:**
+1. Read the [hands-on-lab README](./hands-on-lab/README.md)
+2. Run `azd up` in the `hands-on-lab/` directory
+3. Follow the [Skillable instructions](./hands-on-lab/lab/skillable-instructions.md) or use standalone
 
 ## Contributing
 

--- a/samples/hands-on-lab/.gitattributes
+++ b/samples/hands-on-lab/.gitattributes
@@ -1,0 +1,10 @@
+# Force Unix line endings for shell scripts (critical for bash execution)
+*.sh text eol=lf
+*.bash text eol=lf
+*.py text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.bicep text eol=lf
+*.bicepparam text eol=lf

--- a/samples/hands-on-lab/README.md
+++ b/samples/hands-on-lab/README.md
@@ -1,0 +1,183 @@
+# Azure SRE Agent Hands-On Lab
+
+Deploy an Azure SRE Agent connected to a sample application with a single `azd up` command. Watch it diagnose and remediate issues autonomously.
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) | 2.60+ | `brew install azure-cli` |
+| [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) | 1.9+ | `brew install azd` |
+| [Git](https://git-scm.com/) | 2.x | `brew install git` |
+
+**Azure Requirements:**
+- Active Azure subscription with **Owner** or **User Access Administrator** role
+- `Microsoft.App` resource provider registered on the subscription
+
+**Optional (for GitHub integration):**
+- GitHub account with a [Personal Access Token](https://github.com/settings/tokens) (repo scope)
+
+## Quick Start
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/dm-chelupati/sre-agent-lab.git
+cd sre-agent-lab
+
+# 2. Sign in to Azure
+az login
+azd auth login
+
+# 3. Create environment
+azd env new sre-lab
+
+# 4. (Optional) Set GitHub PAT for bonus scenarios
+azd env set GITHUB_PAT <your-github-pat>
+
+# 5. Deploy everything
+azd up
+# Select your subscription and eastus2 as the region
+```
+
+Deployment takes ~8-12 minutes. When complete, you'll see the SRE Agent portal URL and Grubify app URL.
+
+## Post-Deployment: Retry & Update
+
+After the initial `azd up`, you can re-run the post-provision script to update configs without redeploying infrastructure:
+
+```bash
+# Re-run full setup (rebuilds container images + re-uploads everything)
+./scripts/post-provision.sh
+
+# Skip container image builds (just update KB, subagents, response plan)
+./scripts/post-provision.sh --retry
+
+# Skip builds only (still re-creates everything from scratch)
+./scripts/post-provision.sh --skip-build
+```
+
+### `--retry` vs `--skip-build`
+
+| Flag | Container Build | KB Upload | Subagents | Response Plan |
+|------|----------------|-----------|-----------|---------------|
+| *(none)* | Yes | Yes | Yes (upsert) | Yes |
+| `--skip-build` | **Skip** | Yes | Yes (upsert) | Yes |
+| `--retry` | **Skip** | Yes (always) | Yes (upsert) | **Skip if exists** |
+
+**Common scenarios:**
+- **Changed a subagent prompt or KB file?** → `./scripts/post-provision.sh --retry`
+- **Added a new KB file to `knowledge-base/`?** → `./scripts/post-provision.sh --retry` (auto-discovers all `*.md` files)
+- **Changed container app code?** → `./scripts/post-provision.sh` (full rebuild)
+- **Response plan 405 error?** → Wait 30s and run `./scripts/post-provision.sh --retry`
+
+## What Gets Deployed
+
+| Component | Azure Service | Purpose |
+|-----------|--------------|---------|
+| SRE Agent | `Microsoft.App/agents` | AI agent for incident investigation |
+| Grubify App | Azure Container Apps | Sample app to monitor |
+| Log Analytics | `Microsoft.OperationalInsights/workspaces` | Log storage |
+| App Insights | `Microsoft.Insights/components` | Request tracing |
+| Alert Rules | `Microsoft.Insights/metricAlerts` | HTTP 5xx and error alerts |
+| Managed Identity | `Microsoft.ManagedIdentity` | Reader access for agent |
+
+**Post-provision (automated via REST API):**
+- Knowledge base: HTTP error runbook + app architecture doc + incident report template
+- Incident handler subagent with diagnostic tools
+- Incident response plan for HTTP 500 alerts
+- (If GitHub PAT) GitHub MCP connector + code-analyzer + issue-triager subagents + scheduled triage task
+
+## Lab Scenarios
+
+### Scenario 1: IT Operations (No GitHub required)
+
+Break the app and watch the agent investigate:
+
+```bash
+./scripts/break-app.sh
+```
+
+Then open [sre.azure.com](https://sre.azure.com) → Incidents to watch the agent:
+1. Detect the Azure Monitor alert
+2. Query Log Analytics for error patterns
+3. Reference the HTTP errors runbook
+4. Apply remediation (restart/scale)
+5. Summarize with root cause and evidence
+
+### Scenario 2: Developer (Requires GitHub)
+
+Ask the agent to search source code for root causes:
+- File:line references to problematic code
+- Correlation of production errors to code changes
+- Suggested fixes with before/after examples
+
+### Scenario 3: Workflow Automation (Requires GitHub)
+
+Create sample support issues and let the agent triage them:
+
+```bash
+./scripts/create-sample-issues.sh <owner/repo>
+```
+
+The agent classifies issues (Documentation, Bug, Feature Request), applies labels, and posts triage comments following the runbook.
+
+## Adding GitHub Later
+
+If you skipped GitHub during setup:
+
+```bash
+export GITHUB_PAT=<your-pat>
+./scripts/setup-github.sh
+```
+
+## Cleanup
+
+```bash
+azd down --purge
+```
+
+## Repository Structure
+
+```
+sre-agent-lab/
+├── azure.yaml                      # azd template
+├── infra/
+│   ├── main.bicep                  # Subscription-scoped entry point
+│   ├── main.bicepparam             # Parameter defaults
+│   ├── resources.bicep             # Resource group module orchestrator
+│   └── modules/
+│       ├── sre-agent.bicep         # Microsoft.App/agents resource
+│       ├── identity.bicep          # Managed identity + RBAC
+│       ├── monitoring.bicep        # Log Analytics + App Insights
+│       ├── container-app.bicep     # Grubify Container App
+│       └── alert-rules.bicep       # Azure Monitor alert rules
+├── knowledge-base/
+│   ├── http-500-errors.md          # HTTP error investigation runbook
+│   ├── grubify-architecture.md     # App architecture reference
+│   ├── incident-report-template.md # GitHub issue formatting template
+│   └── github-issue-triage.md      # Issue triage runbook (GitHub)
+├── sre-config/
+│   ├── connectors/
+│   │   └── github-mcp.yaml        # GitHub MCP connector
+│   └── agents/
+│       ├── incident-handler-core.yaml   # Core subagent (no GitHub)
+│       ├── incident-handler-full.yaml   # Full subagent (with GitHub)
+│       ├── code-analyzer.yaml           # Developer persona subagent
+│       └── issue-triager.yaml           # Triage persona subagent
+├── scripts/
+│   ├── post-provision.sh           # azd postprovision hook
+│   ├── yaml-to-api-json.py         # Converts YAML agent specs to API JSON
+│   ├── break-app.sh                # Fault injection script
+│   ├── setup-github.sh             # Add GitHub integration later
+│   └── create-sample-issues.sh     # Create triage test issues
+└── lab/
+    └── skillable-instructions.md   # Skillable lab markdown (copy into Skillable)
+```
+
+## Regions
+
+SRE Agent is available in: `eastus2`, `swedencentral`, `australiaeast`
+
+## License
+
+MIT

--- a/samples/hands-on-lab/azure.yaml
+++ b/samples/hands-on-lab/azure.yaml
@@ -1,0 +1,17 @@
+# Azure Developer CLI (azd) template for SRE Agent Lab
+# Run: azd up
+name: sre-agent-lab
+metadata:
+  template: sre-agent-lab@1.0.0
+
+infra:
+  provider: bicep
+  path: infra
+
+# No services block — container image is built in the cloud via ACR Tasks
+# in the post-provision hook. No Docker Desktop needed on the lab machine.
+
+hooks:
+  postprovision:
+    shell: sh
+    run: bash ./scripts/post-provision.sh

--- a/samples/hands-on-lab/infra/main.bicep
+++ b/samples/hands-on-lab/infra/main.bicep
@@ -1,0 +1,57 @@
+targetScope = 'subscription'
+
+@description('Name of the environment (auto-populated by azd)')
+param environmentName string
+
+@description('Primary location for all resources')
+@allowed(['swedencentral', 'eastus2', 'australiaeast'])
+param location string = 'eastus2'
+
+@description('GitHub Personal Access Token (optional - enables GitHub integration)')
+@secure()
+param githubPat string = ''
+
+// Resource group
+var resourceGroupName = 'rg-${environmentName}'
+
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+// Deploy all resources into the resource group
+module resources 'resources.bicep' = {
+  name: 'resources-deployment'
+  scope: rg
+  params: {
+    environmentName: environmentName
+    location: location
+  }
+}
+
+// ============================================================
+// Subscription-scoped RBAC for SRE Agent managed identity
+// ============================================================
+module subscriptionRbac 'modules/subscription-rbac.bicep' = {
+  name: 'subscription-rbac'
+  params: {
+    principalId: resources.outputs.identityPrincipalId
+  }
+}
+
+// Outputs consumed by azd and post-provision script
+output AZURE_RESOURCE_GROUP string = rg.name
+output AZURE_LOCATION string = location
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.acrLoginServer
+output AZURE_CONTAINER_REGISTRY_NAME string = resources.outputs.acrName
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = resources.outputs.containerAppEnvName
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = resources.outputs.containerAppEnvId
+output SRE_AGENT_NAME string = resources.outputs.agentName
+output SRE_AGENT_ENDPOINT string = resources.outputs.agentEndpoint
+output AGENT_PORTAL_URL string = resources.outputs.agentPortalUrl
+output CONTAINER_APP_URL string = resources.outputs.containerAppUrl
+output CONTAINER_APP_NAME string = resources.outputs.containerAppName
+output FRONTEND_APP_URL string = resources.outputs.frontendAppUrl
+output FRONTEND_APP_NAME string = resources.outputs.frontendAppName
+output LOG_ANALYTICS_WORKSPACE_ID string = resources.outputs.logAnalyticsWorkspaceId
+output APP_INSIGHTS_CONNECTION_STRING string = resources.outputs.appInsightsConnectionString

--- a/samples/hands-on-lab/infra/main.bicepparam
+++ b/samples/hands-on-lab/infra/main.bicepparam
@@ -1,0 +1,5 @@
+using './main.bicep'
+
+param environmentName = readEnvironmentVariable('AZURE_ENV_NAME', 'srelab')
+param location = readEnvironmentVariable('AZURE_LOCATION', 'eastus2')
+param githubPat = readEnvironmentVariable('GITHUB_PAT', '')

--- a/samples/hands-on-lab/infra/modules/alert-rules.bicep
+++ b/samples/hands-on-lab/infra/modules/alert-rules.bicep
@@ -1,0 +1,65 @@
+@description('Container App resource ID')
+param containerAppId string
+
+@description('Environment name for naming')
+param environmentName string
+
+// ============================================================
+// Action Group (minimal - SRE Agent picks up alerts via managed resources)
+// ============================================================
+resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: 'ag-sre-lab-${environmentName}'
+  location: 'global'
+  properties: {
+    groupShortName: 'SRELabAG'
+    enabled: true
+  }
+}
+
+// ============================================================
+// Single alert: HTTP 5xx errors on Container App
+// One alert keeps it clean — the agent investigates the root cause
+// (memory leak, OOM, code bug) regardless of which symptom triggered it.
+// ============================================================
+resource http5xxAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'alert-http-5xx-${environmentName}'
+  location: 'global'
+  properties: {
+    description: 'Alert when Grubify returns HTTP 5xx errors — triggers SRE Agent investigation'
+    severity: 3
+    enabled: true
+    scopes: [
+      containerAppId
+    ]
+    evaluationFrequency: 'PT1M'
+    windowSize: 'PT5M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'http5xx'
+          metricName: 'Requests'
+          metricNamespace: 'microsoft.app/containerapps'
+          operator: 'GreaterThan'
+          threshold: 5
+          timeAggregation: 'Total'
+          dimensions: [
+            {
+              name: 'statusCodeCategory'
+              operator: 'Include'
+              values: [
+                '5xx'
+              ]
+            }
+          ]
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      {
+        actionGroupId: actionGroup.id
+      }
+    ]
+  }
+}

--- a/samples/hands-on-lab/infra/modules/container-app.bicep
+++ b/samples/hands-on-lab/infra/modules/container-app.bicep
@@ -1,0 +1,164 @@
+@description('Location for resources')
+param location string
+
+@description('Container App Environment name')
+param containerAppEnvName string
+
+@description('Container App name')
+param containerAppName string
+
+@description('Log Analytics Workspace resource ID')
+param logAnalyticsWorkspaceId string
+
+@description('Log Analytics Workspace shared key')
+@secure()
+param logAnalyticsWorkspaceKey string
+
+// Container App Environment
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: containerAppEnvName
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: reference(logAnalyticsWorkspaceId, '2023-09-01').customerId
+        sharedKey: logAnalyticsWorkspaceKey
+      }
+    }
+  }
+}
+
+// Azure Container Registry — used by post-provision hook to build Grubify image
+// via 'az acr build' (cloud-side build, no local Docker needed)
+var acrName = replace('acr${containerAppName}', '-', '')
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: length(acrName) > 50 ? substring(acrName, 0, 50) : acrName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: true
+  }
+}
+
+// Grubify Container App — starts with placeholder image, updated by post-provision hook
+resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: containerAppName
+  location: location
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      registries: [
+        {
+          server: acr.properties.loginServer
+          username: acr.listCredentials().username
+          passwordSecretRef: 'acr-password'
+        }
+      ]
+      secrets: [
+        {
+          name: 'acr-password'
+          value: acr.listCredentials().passwords[0].value
+        }
+      ]
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'auto'
+        allowInsecure: false
+      }
+    }
+    template: {
+      containers: [
+        {
+          image: 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+          name: 'grubify-api'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'ASPNETCORE_URLS'
+              value: 'http://+:8080'
+            }
+            {
+              name: 'ASPNETCORE_ENVIRONMENT'
+              value: 'Production'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 5
+      }
+    }
+  }
+}
+
+// Grubify Frontend Container App
+var frontendAppName = replace(containerAppName, 'grubify', 'grubify-fe')
+resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: frontendAppName
+  location: location
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      registries: [
+        {
+          server: acr.properties.loginServer
+          username: acr.listCredentials().username
+          passwordSecretRef: 'acr-password'
+        }
+      ]
+      secrets: [
+        {
+          name: 'acr-password'
+          value: acr.listCredentials().passwords[0].value
+        }
+      ]
+      ingress: {
+        external: true
+        targetPort: 80
+        transport: 'auto'
+        allowInsecure: false
+      }
+    }
+    template: {
+      containers: [
+        {
+          image: 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+          name: 'grubify-frontend'
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+          env: [
+            {
+              name: 'REACT_APP_API_BASE_URL'
+              value: 'https://${containerApp.properties.configuration.ingress.fqdn}/api'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 3
+      }
+    }
+  }
+}
+
+// Outputs
+output containerAppId string = containerApp.id
+output containerAppName string = containerApp.name
+output containerAppUrl string = 'https://${containerApp.properties.configuration.ingress.fqdn}'
+output frontendAppName string = frontendApp.name
+output frontendAppUrl string = 'https://${frontendApp.properties.configuration.ingress.fqdn}'
+output containerAppEnvId string = containerAppEnv.id
+output containerAppEnvName string = containerAppEnv.name
+output acrName string = acr.name
+output acrLoginServer string = acr.properties.loginServer

--- a/samples/hands-on-lab/infra/modules/identity.bicep
+++ b/samples/hands-on-lab/infra/modules/identity.bicep
@@ -1,0 +1,19 @@
+@description('Location for resources')
+param location string
+
+@description('Managed Identity name')
+param identityName string
+
+// User-Assigned Managed Identity for the SRE Agent
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: identityName
+  location: location
+  properties: {
+    isolationScope: 'Regional'
+  }
+}
+
+// Outputs
+output identityId string = userAssignedIdentity.id
+output identityName string = userAssignedIdentity.name
+output identityPrincipalId string = userAssignedIdentity.properties.principalId

--- a/samples/hands-on-lab/infra/modules/monitoring.bicep
+++ b/samples/hands-on-lab/infra/modules/monitoring.bicep
@@ -1,0 +1,40 @@
+@description('Location for resources')
+param location string
+
+@description('Log Analytics Workspace name')
+param logAnalyticsName string
+
+@description('Application Insights name')
+param appInsightsName string
+
+// Log Analytics Workspace
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: logAnalyticsName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// Application Insights (linked to Log Analytics)
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    Request_Source: 'IbizaAIExtension'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+  }
+}
+
+// Outputs
+output logAnalyticsWorkspaceId string = logAnalyticsWorkspace.id
+output logAnalyticsWorkspaceName string = logAnalyticsWorkspace.name
+output logAnalyticsWorkspaceKey string = logAnalyticsWorkspace.listKeys().primarySharedKey
+output appInsightsId string = applicationInsights.id
+output appInsightsAppId string = applicationInsights.properties.AppId
+output appInsightsConnectionString string = applicationInsights.properties.ConnectionString

--- a/samples/hands-on-lab/infra/modules/sre-agent.bicep
+++ b/samples/hands-on-lab/infra/modules/sre-agent.bicep
@@ -1,0 +1,80 @@
+@description('Location for resources')
+param location string
+
+@description('SRE Agent name')
+param agentName string
+
+@description('User-Assigned Managed Identity resource ID')
+param identityId string
+
+@description('User-Assigned Managed Identity principal ID')
+param identityPrincipalId string
+
+@description('Application Insights App ID')
+param appInsightsAppId string
+
+@description('Application Insights Connection String')
+param appInsightsConnectionString string
+
+@description('Application Insights resource ID')
+param appInsightsId string
+
+@description('Resource Group ID to add as managed resource')
+param managedResourceGroupId string
+
+// SRE Agent Administrator role ID
+var sreAgentAdminRoleId = 'e79298df-d852-4c6d-84f9-5d13249d1e55'
+
+// Create the SRE Agent
+#disable-next-line BCP081
+resource sreAgent 'Microsoft.App/agents@2025-05-01-preview' = {
+  name: agentName
+  location: location
+  tags: {
+    'hidden-link: /app-insights-resource-id': appInsightsId
+    'lab': 'sre-agent-lab'
+  }
+  identity: {
+    type: 'SystemAssigned, UserAssigned'
+    userAssignedIdentities: {
+      '${identityId}': {}
+    }
+  }
+  properties: {
+    knowledgeGraphConfiguration: {
+      managedResources: [
+        managedResourceGroupId
+      ]
+      identity: identityId
+    }
+    actionConfiguration: {
+      mode: 'autonomous'
+      identity: identityId
+      accessLevel: 'Low'
+    }
+    mcpServers: []
+    logConfiguration: {
+      applicationInsightsConfiguration: {
+        appId: appInsightsAppId
+        connectionString: appInsightsConnectionString
+      }
+    }
+  }
+}
+
+// Assign SRE Agent Administrator role to the deployer
+resource sreAgentAdminRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(sreAgent.id, deployer().objectId, sreAgentAdminRoleId)
+  scope: sreAgent
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', sreAgentAdminRoleId)
+    principalId: deployer().objectId
+    principalType: 'User'
+  }
+}
+
+// Outputs
+output agentName string = sreAgent.name
+output agentId string = sreAgent.id
+output agentEndpoint string = sreAgent.properties.agentEndpoint
+output agentPortalUrl string = 'https://sre.azure.com'

--- a/samples/hands-on-lab/infra/modules/subscription-rbac.bicep
+++ b/samples/hands-on-lab/infra/modules/subscription-rbac.bicep
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+@description('Principal ID of the managed identity to assign roles to')
+param principalId string
+
+// Subscription-scoped RBAC for SRE Agent managed identity
+// These roles allow the agent to read resources, query logs, and manage container apps
+
+var roles = [
+  {
+    name: 'Reader'
+    id: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+  }
+  {
+    name: 'Monitoring Reader'
+    id: '43d0d8ad-25c7-4714-9337-8ba259a9fe05'
+  }
+  {
+    name: 'Monitoring Contributor'
+    id: '749f88d5-cbae-40b8-bcfc-e573ddc772fa'
+  }
+  {
+    name: 'Log Analytics Reader'
+    id: '73c42c96-874c-492b-b04d-ab87d138a893'
+  }
+  {
+    name: 'Container Apps Contributor'
+    id: '358470bc-b998-42bd-ab17-a7e34c199c0f'
+  }
+]
+
+resource roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for role in roles: {
+  name: guid(subscription().id, principalId, role.id)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role.id)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}]

--- a/samples/hands-on-lab/infra/resources.bicep
+++ b/samples/hands-on-lab/infra/resources.bicep
@@ -1,0 +1,99 @@
+@description('Name of the environment')
+param environmentName string
+
+@description('Location for all resources')
+param location string
+
+// ============================================================
+// Variables
+// ============================================================
+var uniqueSuffix = uniqueString(resourceGroup().id, environmentName)
+var agentName = 'sre-agent-${uniqueSuffix}'
+var logAnalyticsName = 'law-${uniqueSuffix}'
+var appInsightsName = 'appi-${uniqueSuffix}'
+var identityName = 'id-sre-${uniqueSuffix}'
+var containerAppEnvName = 'cae-${uniqueSuffix}'
+var containerAppName = 'ca-grubify-${uniqueSuffix}'
+
+// ============================================================
+// Module: Monitoring (Log Analytics + App Insights)
+// ============================================================
+module monitoring 'modules/monitoring.bicep' = {
+  name: 'monitoring'
+  params: {
+    location: location
+    logAnalyticsName: logAnalyticsName
+    appInsightsName: appInsightsName
+  }
+}
+
+// ============================================================
+// Module: Managed Identity + RBAC
+// ============================================================
+module identity 'modules/identity.bicep' = {
+  name: 'identity'
+  params: {
+    location: location
+    identityName: identityName
+  }
+}
+
+// ============================================================
+// Module: Container App (Grubify)
+// ============================================================
+module containerApp 'modules/container-app.bicep' = {
+  name: 'container-app'
+  params: {
+    location: location
+    containerAppEnvName: containerAppEnvName
+    containerAppName: containerAppName
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
+    logAnalyticsWorkspaceKey: monitoring.outputs.logAnalyticsWorkspaceKey
+  }
+}
+
+// ============================================================
+// Module: SRE Agent
+// ============================================================
+module sreAgent 'modules/sre-agent.bicep' = {
+  name: 'sre-agent'
+  params: {
+    location: location
+    agentName: agentName
+    identityId: identity.outputs.identityId
+    identityPrincipalId: identity.outputs.identityPrincipalId
+    appInsightsAppId: monitoring.outputs.appInsightsAppId
+    appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
+    appInsightsId: monitoring.outputs.appInsightsId
+    managedResourceGroupId: resourceGroup().id
+  }
+}
+
+// ============================================================
+// Module: Alert Rules
+// ============================================================
+module alertRules 'modules/alert-rules.bicep' = {
+  name: 'alert-rules'
+  params: {
+    containerAppId: containerApp.outputs.containerAppId
+    environmentName: environmentName
+  }
+}
+
+// ============================================================
+// Outputs
+// ============================================================
+output agentName string = sreAgent.outputs.agentName
+output agentEndpoint string = sreAgent.outputs.agentEndpoint
+output agentPortalUrl string = sreAgent.outputs.agentPortalUrl
+output containerAppUrl string = containerApp.outputs.containerAppUrl
+output containerAppName string = containerApp.outputs.containerAppName
+output frontendAppUrl string = containerApp.outputs.frontendAppUrl
+output frontendAppName string = containerApp.outputs.frontendAppName
+output containerAppEnvName string = containerApp.outputs.containerAppEnvName
+output containerAppEnvId string = containerApp.outputs.containerAppEnvId
+output acrName string = containerApp.outputs.acrName
+output acrLoginServer string = containerApp.outputs.acrLoginServer
+output identityPrincipalId string = identity.outputs.identityPrincipalId
+output logAnalyticsWorkspaceId string = monitoring.outputs.logAnalyticsWorkspaceId
+output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString

--- a/samples/hands-on-lab/knowledge-base/github-issue-triage.md
+++ b/samples/hands-on-lab/knowledge-base/github-issue-triage.md
@@ -1,0 +1,193 @@
+# Grubify App Issue Triage Runbook
+
+Triage incoming customer issues for the Grubify food ordering application. Focus on issues with **[Customer Issue]** in the title — these are user-reported problems. Classify them, add labels, and post a triage comment.
+
+---
+
+## Step 1: Get Open Issues
+
+Fetch all open issues from the repo. Focus on issues that have **[Customer Issue]** in the title and are unassigned/unlabeled. Skip issues that don't have the [Customer Issue] prefix (those are internal agent-created reports).
+
+---
+
+## Step 2: Handle Each Issue Based on Current State
+
+For each open issue, check its current state:
+
+### Case A: Already triaged (bot comment + labels exist, no updates since)
+→ **Skip it** — already handled.
+
+### Case B: Has labels but NO bot comment
+This happens when another subagent (incident-handler or code-analyzer) created the issue with labels already applied. The issue is valid and already categorized.
+
+**Post an acknowledgment comment:**
+```
+🤖 **Grubify SRE Agent Bot**
+
+This issue has been reviewed. Labels are already applied and the team is looking into it.
+
+Issue summary: [brief summary from issue body]
+Current labels: [list existing labels]
+
+🔍 Status: **Under investigation by the team**
+```
+
+→ Do NOT change existing labels — they were set by the creating agent.
+
+### Case C: Has a bot comment but labels were removed or changed
+→ **Re-triage** — classify again following Step 3 below.
+
+### Case D: No labels, no bot comment (new untriaged issue)
+→ **Triage it** — continue to Step 3.
+
+---
+
+## Step 3: Classify the Issue
+
+Read the title and description. Pick ONE category:
+
+| Category | What it looks like |
+|----------|-------------------|
+| **Bug** | "Error", "500", "crash", "not working", "broken", "OOM", "memory leak" |
+| **Performance** | "slow", "timeout", "high CPU", "high memory", "latency" |
+| **Feature Request** | "Would be nice to have...", "Please add...", suggestions |
+| **Question** | "How do I...", "Where can I find...", configuration help |
+
+---
+
+## Step 4: Handle Bugs
+
+### Pick a sub-category:
+
+| Type | Examples |
+|------|----------|
+| **API Bug** | Cart API errors, order failures, menu not loading, 500 errors |
+| **Frontend Bug** | UI broken, page not rendering, CORS errors, failed to load |
+| **Infrastructure** | Container restarts, OOM kills, deployment failures, scaling issues |
+| **Memory Leak** | Memory growing over time, cart accumulating without cleanup |
+
+### Check if user provided enough info:
+
+**Need at minimum:**
+- What happened (error message or behavior)
+- Steps to reproduce
+- Which endpoint or page was affected
+
+### If info is missing:
+
+**Post comment:**
+```
+🤖 **Grubify SRE Agent Bot**
+
+Thanks for reporting this issue with Grubify. To investigate, we need:
+- [list what's missing]
+
+⚠️ Status: **Waiting for info from user**
+```
+
+**Add labels:** `needs-more-info` + sub-category label
+
+### If info is complete:
+
+**Post comment:**
+```
+🤖 **Grubify SRE Agent Bot**
+
+Thanks for the details. This bug report is ready for investigation.
+
+Issue summary: [brief summary]
+Affected component: [API / Frontend / Infrastructure]
+Severity: [Critical / High / Medium / Low]
+
+✅ Status: **Ready for investigation**
+```
+
+**Add labels:** `bug` + sub-category label + severity label
+
+**Sub-category labels:**
+- `api-bug`
+- `frontend-bug`
+- `infrastructure`
+- `memory-leak`
+
+---
+
+## Step 5: Handle Performance Issues
+
+**Post comment:**
+```
+🤖 **Grubify SRE Agent Bot**
+
+Performance issue identified.
+
+Affected area: [API response time / Memory usage / CPU / Scaling]
+Recommended investigation: [Check metrics / Review logs / Load test]
+
+🔧 Status: **Performance investigation needed**
+```
+
+**Add labels:** `performance` + relevant sub-category
+
+---
+
+## Step 6: Handle Feature Requests
+
+**Post comment:**
+```
+🤖 **Grubify SRE Agent Bot**
+
+Thanks for the suggestion for Grubify!
+
+[If feature exists: explain how to use it]
+[If new: "This is a great idea. We'll consider it for future development."]
+
+💡 Status: **Feature request**
+```
+
+**Add labels:** `enhancement`, `feature-request`
+
+---
+
+## Step 7: Handle Questions
+
+**Post comment:**
+```
+🤖 **Grubify SRE Agent Bot**
+
+[Answer the question based on the grubify-architecture knowledge base document]
+
+📖 Status: **Question answered**
+```
+
+**Add labels:** `question`, `answered`
+
+---
+
+## Labels Cheat Sheet
+
+| Situation | Labels to Add |
+|-----------|---------------|
+| Bug, need more info | `needs-more-info` + sub-category |
+| Bug, ready to investigate | `bug` + sub-category + severity |
+| Performance issue | `performance` + sub-category |
+| Feature request | `enhancement`, `feature-request` |
+| Question | `question`, `answered` |
+
+**Severity labels:**
+- `critical` — App completely down, all users affected
+- `high` — Major feature broken, many users affected
+- `medium` — Feature partially broken, workaround exists
+- `low` — Minor issue, cosmetic, edge case
+
+---
+
+## Comment Template
+
+Always start with: `🤖 **Grubify SRE Agent Bot**`
+
+Always end with a status line:
+- `⚠️ Status: **Waiting for info from user**`
+- `✅ Status: **Ready for investigation**`
+- `🔧 Status: **Performance investigation needed**`
+- `💡 Status: **Feature request**`
+- `📖 Status: **Question answered**`

--- a/samples/hands-on-lab/knowledge-base/grubify-architecture.md
+++ b/samples/hands-on-lab/knowledge-base/grubify-architecture.md
@@ -1,0 +1,137 @@
+# Grubify Application Architecture
+
+## Overview
+
+Grubify is a food ordering web application deployed on **Azure Container Apps**. It serves as the monitored application for the SRE Agent lab — the agent investigates and remediates issues with this app.
+
+---
+
+## Infrastructure
+
+| Component | Azure Service | Details |
+|-----------|---------------|---------|
+| **Application** | Azure Container Apps | Node.js API, port 8080, external ingress |
+| **Container Environment** | Container Apps Environment | Linked to Log Analytics |
+| **Logs** | Log Analytics Workspace | Console logs via `ContainerAppConsoleLogs_CL` |
+| **Telemetry** | Application Insights | Request metrics, exceptions, dependencies |
+| **Identity** | User-Assigned Managed Identity | Reader + Monitoring Reader + Log Analytics Reader |
+| **Alerts** | Azure Monitor | Metric alerts for HTTP 5xx, log alerts for errors |
+
+---
+
+## Application Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/restaurants` | GET | List all restaurants |
+| `/api/fooditems` | GET | List all food items / menu |
+| `/api/orders` | GET | List orders |
+| `/api/orders` | POST | Create a new order |
+| `/api/cart/{userId}/items` | GET | Get cart items for a user |
+| `/api/cart/{userId}/items` | POST | Add item to user's cart (**memory leak trigger**) |
+| `/weatherforecast` | GET | Test endpoint — returns sample weather data |
+
+---
+
+## Fault Injection — Memory Leak via Cart API
+
+The `/api/cart/{userId}/items` endpoint stores cart items **in memory** with no eviction policy. Rapid repeated calls cause:
+
+- Memory working set to grow continuously
+- Container to approach its 1Gi memory limit
+- Eventually OOM kill → container restart → HTTP 500/503 errors
+- Azure Monitor fires alerts
+
+**Trigger:** Send rapid POST requests to `/api/cart/demo-user/items`
+```bash
+while true; do
+  curl -X POST "https://<app-url>/api/cart/demo-user/items" \
+    -H "Content-Type: application/json" \
+    -d '{"foodItemId":1,"quantity":1}'
+  sleep 0.5
+done
+```
+
+---
+
+## Source Code
+
+- **GitHub repository:** [github.com/dm-chelupati/grubify](https://github.com/dm-chelupati/grubify)
+- **Language:** Node.js
+- **Container image:** `ghcr.io/dm-chelupati/grubify:latest`
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `server.js` | Main application entry point |
+| `routes/api.js` | API route handlers (menu, orders) |
+| `routes/admin.js` | Admin endpoints including chaos mode |
+| `middleware/errorHandler.js` | Error handling middleware |
+| `Dockerfile` | Container build definition |
+
+---
+
+## Scaling Configuration
+
+| Setting | Value |
+|---------|-------|
+| Min replicas | 1 |
+| Max replicas | 5 |
+| CPU | 0.5 cores |
+| Memory | 1 Gi |
+| Scale rule | HTTP concurrent requests > 50 |
+
+---
+
+## Monitoring & Alerting
+
+### Log Analytics Queries
+
+**Error logs:**
+```kql
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(1h)
+| where Log_s contains "error" or Log_s contains "Error" or Log_s contains "500"
+| summarize ErrorCount = count() by bin(TimeGenerated, 5m)
+| order by TimeGenerated desc
+```
+
+**Container app console output:**
+```kql
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(1h)
+| project TimeGenerated, Log_s, ContainerName_s
+| order by TimeGenerated desc
+| take 50
+```
+
+### Alert Rules
+
+| Alert | Trigger | Severity |
+|-------|---------|----------|
+| HTTP 5xx errors | > 5 requests with 5xx status in 5 min | Sev3 |
+
+A single alert keeps things clean — the SRE Agent investigates the root cause (memory leak, OOM, code bug, etc.) regardless of which symptom triggered it.
+
+These alerts flow automatically to the SRE Agent via the managed resource group configuration.
+
+---
+
+## Known Failure Modes
+
+| Failure | Symptoms | Root Cause |
+|---------|----------|------------|
+| Chaos mode enabled | HTTP 500 on all endpoints | Intentional fault injection via `/admin/chaos` |
+| Memory pressure | Slow responses, OOM restarts | Undersized container (1Gi), memory leak in error path |
+| High CPU | Request timeouts | Unthrottled request processing under load |
+
+---
+
+## Troubleshooting Quick Reference
+
+1. **Check health:** `curl https://<app-url>/health`
+2. **Check logs:** Query `ContainerAppConsoleLogs_CL` in Log Analytics
+3. **Check metrics:** Azure Monitor → Container App → Requests, CPU, Memory
+4. **Restart:** `az containerapp revision restart -g <rg> -n <app> --revision <rev>`
+5. **Scale out:** `az containerapp update -g <rg> -n <app> --min-replicas 3`

--- a/samples/hands-on-lab/knowledge-base/http-500-errors.md
+++ b/samples/hands-on-lab/knowledge-base/http-500-errors.md
@@ -1,0 +1,458 @@
+# HTTP 500 Error Investigation Runbook
+
+## Trigger Keywords
+`500 error`, `internal server error`, `HTTP 500`, `server error`, `application error`, `unresponsive`
+
+## Scope
+Azure Container Apps endpoints returning HTTP 500 errors. Logs stored in Log Analytics Workspace.
+
+## Valid Azure Monitor Metric Names for Container Apps
+**IMPORTANT: Use ONLY these metric names with `az monitor metrics list`:**
+- `UsageNanoCores` — CPU usage (NOT CpuUsage, NOT CPUUsage)
+- `WorkingSetBytes` — Memory usage (NOT MemoryUsage, NOT MemoryWorkingSet)
+- `Requests` — HTTP request count
+- `RestartCount` — Container restarts (OOM indicator)
+- `Replicas` — Active replica count
+- `CpuPercentage` — CPU percentage
+- `MemoryPercentage` — Memory percentage
+
+## Container App Logs CLI
+**Use `az containerapp logs show` with `--tail` (NOT `--since`):**
+```bash
+az containerapp logs show -g <resourceGroup> -n <appName> --tail 300
+az containerapp logs show -g <resourceGroup> -n <appName> --tail 300 --format text
+```
+
+---
+
+## Phase 1: CPU and Memory Metrics (Check First)
+
+### 1.1 CPU Metrics (App Insights / Azure Monitor)
+```kql
+performanceCounters
+| where timestamp > ago(1h)
+| where name == "% Processor Time" or name contains "CPU"
+| summarize AvgCPU = avg(value), MaxCPU = max(value) by bin(timestamp, 5m)
+| order by timestamp desc
+```
+
+### 1.2 Memory Usage Over Time
+```kql
+performanceCounters
+| where timestamp > ago(1h)
+| where name contains "Memory" or name == "Available Bytes" or name == "Private Bytes"
+| summarize AvgMemory = avg(value), MaxMemory = max(value) by bin(timestamp, 5m), name
+| order by timestamp desc
+```
+
+### 1.3 Container App Metrics via Azure Monitor
+```kql
+AzureMetrics
+| where TimeGenerated > ago(1h)
+| where ResourceProvider == "MICROSOFT.APP"
+| where MetricName in ("UsageNanoCores", "WorkingSetBytes", "Requests", "RestartCount")
+| summarize AvgValue = avg(Average), MaxValue = max(Maximum) by bin(TimeGenerated, 5m), MetricName
+| order by TimeGenerated desc
+```
+
+### 1.4 Get Metrics via Azure CLI
+```bash
+# List available metrics for container app
+az monitor metrics list-definitions --resource <resourceId>
+
+# Get CPU usage metrics (last 1 hour)
+az monitor metrics list --resource <resourceId> --metric "UsageNanoCores" --interval PT5M --start-time $(date -u -d '1 hour ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-1H +"%Y-%m-%dT%H:%M:%SZ") --end-time $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Get Memory usage metrics (last 1 hour)
+az monitor metrics list --resource <resourceId> --metric "WorkingSetBytes" --interval PT5M --start-time $(date -u -d '1 hour ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-1H +"%Y-%m-%dT%H:%M:%SZ") --end-time $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Example with full resource ID:
+az monitor metrics list --resource "/subscriptions/cbf44432-7f45-4906-a85d-d2b14a1e8328/resourceGroups/rg-grubify-app/providers/Microsoft.App/containerApps/ca-grubify-api" --metric "UsageNanoCores" --interval PT5M
+```
+
+### 1.5 Memory Pressure Indicators
+```kql
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(1h)
+| where Log_s contains "OutOfMemory" 
+    or Log_s contains "OOM" 
+    or Log_s contains "memory pressure"
+    or Log_s contains "GC"
+    or Log_s contains "heap"
+| project TimeGenerated, Log_s, ContainerName_s
+| order by TimeGenerated desc
+```
+
+### 1.6 Detect High CPU Correlation with Errors
+```kql
+let highCpuTimes = performanceCounters
+| where timestamp > ago(1h)
+| where name contains "CPU"
+| where value > 80
+| summarize by bin(timestamp, 5m);
+requests
+| where timestamp > ago(1h)
+| where resultCode startswith "5"
+| summarize ErrorCount = count() by bin(timestamp, 5m)
+| join kind=inner highCpuTimes on timestamp
+| order by timestamp desc
+```
+
+### Resource Thresholds Reference
+| Metric | Warning | Critical | Action |
+|--------|---------|----------|--------|
+| CPU % | > 70% sustained | > 90% sustained | Scale out replicas |
+| Memory % | > 75% sustained | > 90% sustained | Scale up memory or fix leak |
+| Memory Working Set | Steadily increasing | Near limit | Investigate memory leak |
+
+---
+
+## Phase 2: Initial Triage
+
+### 2.1 Get Container App Details
+```bash
+# Show container app configuration
+az containerapp show -g <resourceGroup> -n <appName> --subscription <subId> --output json
+
+# Example:
+az containerapp show -g rg-grubify-app -n ca-grubify-api --subscription cbf44432-7f45-4906-a85d-d2b14a1e8328 --output json
+```
+
+### 2.2 Get Current Revision Logs
+```bash
+# Get recent logs from active revision (last 300 lines)
+az containerapp logs show -g <resourceGroup> -n <appName> --subscription <subId> --revision <revisionId> --tail 300
+
+# Example:
+az containerapp logs show -g rg-octopets-nov9 -n octopetsapi --subscription cbf44432-7f45-4906-a85d-d2b14a1e8328 --revision octopetsapi--0000003 --tail 300
+
+# If command fails, retry with --format text:
+az containerapp logs show -g rg-octopets-nov9 -n octopetsapi --subscription cbf44432-7f45-4906-a85d-d2b14a1e8328 --revision octopetsapi--0000003 --tail 300 --format text
+```
+
+### 2.3 Quick Error Count (KQL)
+```kql
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(1h)
+| where Log_s contains "error" or Log_s contains "exception" or Log_s contains "500"
+| summarize ErrorCount = count() by bin(TimeGenerated, 5m)
+| order by TimeGenerated desc
+```
+
+---
+
+## Phase 3: Identify Error Patterns
+
+### 3.1 Top Errors by Message
+```kql
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(1h)
+| where Log_s contains "error" or Log_s contains "exception"
+| extend ErrorMessage = extract("(Exception|Error|Failed|Fault).*", 0, Log_s)
+| summarize Count = count(), 
+    FirstSeen = min(TimeGenerated), 
+    LastSeen = max(TimeGenerated)
+by ErrorMessage
+| order by Count desc
+| take 10
+```
+
+### 3.2 Failed HTTP Requests (App Insights)
+```kql
+requests
+| where timestamp > ago(1h)
+| where resultCode startswith "5"
+| summarize FailedCount = count(), 
+    AvgDuration = avg(duration),
+    P95Duration = percentile(duration, 95)
+by name, resultCode, url
+| order by FailedCount desc
+| take 20
+```
+
+### 3.3 Error Rate Over Time
+```kql
+requests
+| where timestamp > ago(1h)
+| summarize 
+    Total = count(),
+    Failed = countif(resultCode startswith "5"),
+    ErrorRate = round(100.0 * countif(resultCode startswith "5") / count(), 2)
+by bin(timestamp, 5m)
+| order by timestamp desc
+```
+
+---
+
+## Phase 4: Exception Details
+
+### 4.1 Top Exceptions with Stack Traces
+```kql
+exceptions
+| where timestamp > ago(1h)
+| summarize Count = count(), 
+    FirstSeen = min(timestamp),
+    LastSeen = max(timestamp)
+by type, problemId, outerMessage
+| order by Count desc
+| take 10
+```
+
+### 4.2 Full Exception Details (Sample)
+```kql
+exceptions
+| where timestamp > ago(1h)
+| project timestamp, type, outerMessage, innermostMessage, details, operation_Id
+| order by timestamp desc
+| take 5
+```
+
+### 4.3 Trace Correlation for Specific Error
+```kql
+// Replace <operation_Id> with value from exceptions query
+let targetOpId = "<operation_Id>";
+union requests, dependencies, traces, exceptions
+| where operation_Id == targetOpId
+| project timestamp, itemType, name, resultCode, duration, message, outerMessage
+| order by timestamp asc
+```
+
+---
+
+## Phase 5: Dependency Health Check
+
+### 5.1 Failing Dependencies
+```kql
+dependencies
+| where timestamp > ago(1h)
+| where success == false
+| summarize FailureCount = count(), 
+    AvgDuration = avg(duration)
+by type, target, resultCode, name
+| order by FailureCount desc
+| take 10
+```
+
+### 5.2 Dependency Latency Spikes
+```kql
+dependencies
+| where timestamp > ago(1h)
+| summarize 
+    AvgDuration = avg(duration),
+    P95Duration = percentile(duration, 95),
+    P99Duration = percentile(duration, 99),
+    CallCount = count()
+by bin(timestamp, 5m), type, target
+| where P95Duration > 1000  // Flag slow dependencies (>1s)
+| order by timestamp desc
+```
+
+### 5.3 Database Connection Issues
+```kql
+dependencies
+| where timestamp > ago(1h)
+| where type == "SQL" or type contains "database" or type contains "cosmos"
+| summarize 
+    Total = count(),
+    Failed = countif(success == false),
+    AvgDuration = avg(duration)
+by target, name
+| extend FailRate = round(100.0 * Failed / Total, 2)
+| order by FailRate desc
+```
+
+---
+
+## Phase 6: Container Health
+
+### 6.1 Container Restarts/Crashes
+```kql
+ContainerAppSystemLogs_CL
+| where TimeGenerated > ago(1h)
+| where Log_s contains "restart" or Log_s contains "crash" or Log_s contains "OOMKilled"
+| project TimeGenerated, Log_s, ContainerName_s, RevisionName_s
+| order by TimeGenerated desc
+```
+
+### 6.2 Resource Exhaustion (OOM)
+```kql
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(1h)
+| where Log_s contains "OutOfMemory" or Log_s contains "OOM" or Log_s contains "memory"
+| project TimeGenerated, Log_s, ContainerName_s
+| order by TimeGenerated desc
+```
+
+### 6.3 Check Managed Environment Health
+```bash
+az containerapp env show --ids <resourceId> --subscription <subId>
+```
+
+---
+
+## Phase 7: Deployment Correlation
+
+### 7.1 Recent Deployments
+```kql
+ContainerAppSystemLogs_CL
+| where TimeGenerated > ago(24h)
+| where Log_s contains "revision" or Log_s contains "deploy"
+| project TimeGenerated, Log_s, RevisionName_s
+| order by TimeGenerated desc
+```
+
+### 7.2 Errors After Deployment (Timeline)
+```kql
+let deployTime = datetime(2025-12-19T10:00:00Z);  // Replace with actual deploy time
+ContainerAppConsoleLogs_CL
+| where TimeGenerated between (deployTime .. (deployTime + 2h))
+| where Log_s contains "error" or Log_s contains "exception"
+| summarize ErrorCount = count() by bin(TimeGenerated, 5m)
+| order by TimeGenerated asc
+```
+
+---
+
+## Phase 8: User Impact Assessment
+
+### 8.1 Affected Users Count
+```kql
+requests
+| where timestamp > ago(1h)
+| where resultCode startswith "5"
+| summarize 
+    AffectedUsers = dcount(user_Id),
+    AffectedSessions = dcount(session_Id),
+    FailedRequests = count()
+```
+
+### 8.2 Geographic Distribution of Errors
+```kql
+requests
+| where timestamp > ago(1h)
+| where resultCode startswith "5"
+| summarize ErrorCount = count() by client_CountryOrRegion
+| order by ErrorCount desc
+| take 10
+```
+
+---
+
+## Quick Diagnosis Checklist
+
+| Check | Phase | What to Look For |
+|-------|-------|------------------|
+| CPU/Memory spikes | Phase 1 | High CPU or memory = resource exhaustion |
+| Error spike timing | Phase 3.3 | Sudden spike = deployment or external trigger |
+| Exception type | Phase 4.1 | NullRef = code bug, Timeout = dependency |
+| Dependency failures | Phase 5.1 | DB/API connection issues |
+| Container restarts | Phase 6.1 | OOM = scale up or memory leak |
+| Recent deploy | Phase 7.1 | Errors started after deploy = rollback candidate |
+
+---
+
+## Common Root Causes
+
+| Symptom | Likely Cause | Next Step |
+|---------|--------------|-----------|
+| High CPU + errors | Resource exhaustion | Scale out replicas |
+| High Memory + OOM | Memory leak or undersized | Scale up memory, investigate leak |
+| Sudden spike after deploy | Bad code release | Rollback to previous revision |
+| Dependency timeouts | Database/API overload | Check dependency health |
+| Connection refused | Service down or network issue | Check target service status |
+| NullReferenceException | Code bug | Trace specific request, review code |
+
+---
+
+## Escalation Criteria
+
+Escalate immediately if:
+- Error rate > 50% for 5+ minutes
+- All requests failing (100% error rate)
+- OOM kills happening repeatedly
+- Database connection pool exhausted
+- Multiple services affected simultaneously
+
+---
+
+## Phase 9: Send Analysis Email
+
+After completing investigation, send an email summary to the incident stakeholders.
+
+**Send to:** dchelupati@microsoft.com
+
+### Email Structure
+
+**Subject:** `[Incident {incidentID}] HTTP 500 Error Analysis - {appName}`
+
+**Body should include:**
+
+1. **Incident Summary**
+   - App name, environment, incident start time (UTC)
+   - Current error rate and affected user count
+
+2. **Key Findings**
+   - CPU/Memory status at time of incident
+   - Top error messages with counts
+   - Suspected root cause
+   - Timeline of when errors started
+
+3. **Evidence**
+   - Resource metrics (CPU/Memory charts or values)
+   - Top 3 exception types with sample stack traces
+   - Failing endpoints with request counts
+   - Dependency failures if applicable
+   - Include KQL queries used (for reproducibility)
+
+4. **Recommended Actions**
+   - Immediate: rollback, scale, restart
+   - Follow-up: code fix, config change, monitoring
+
+5. **Links**
+   - Incident link (PagerDuty/ServiceNow)
+   - Log Analytics workspace query link
+   - GitHub issue (if created)
+
+### Sample Email Template
+
+```
+Subject: [Incident INC0012345] HTTP 500 Error Analysis - ca-grubify-api
+
+## Summary
+- **App:** ca-grubify-api (Production)
+- **Incident Start:** 2025-12-19T14:30:00Z
+- **Error Rate:** 45% (was 0.1% before incident)
+- **Affected Users:** 1,247
+
+## Resource Status
+- **CPU:** 92% avg (Critical - exceeded 90% threshold)
+- **Memory:** 78% avg (Warning - approaching limit)
+
+## Key Findings
+- **Root Cause:** CPU saturation causing request timeouts
+- **Timeline:** CPU spike at 14:25 UTC, errors started at 14:28 UTC
+- **Top Exception:** TimeoutException (1,832 occurrences)
+
+## Evidence
+### Resource Metrics
+| Time (UTC) | CPU % | Memory % |
+|------------|-------|----------|
+| 14:25 | 45% | 72% |
+| 14:30 | 92% | 78% |
+| 14:35 | 95% | 81% |
+
+### Top Errors (Last Hour)
+| Error | Count | First Seen |
+|-------|-------|------------|
+| TimeoutException | 1,832 | 14:28 UTC |
+| SqlException | 445 | 14:30 UTC |
+
+## Recommended Actions
+1. **Immediate:** Scale out to 5 replicas (currently 2)
+2. **Follow-up:** Investigate CPU-intensive operation in OrderService.cs
+
+## Links
+- [PagerDuty Incident](https://pagerduty.com/incidents/INC0012345)
+- [Log Analytics Query](https://portal.azure.com/...)
+- [GitHub Issue #456](https://github.com/org/repo/issues/456)
+```

--- a/samples/hands-on-lab/knowledge-base/incident-report-template.md
+++ b/samples/hands-on-lab/knowledge-base/incident-report-template.md
@@ -1,0 +1,126 @@
+# GitHub Issue Formatting — Incident Report Template
+
+When creating a GitHub issue for an incident, use the following structured format. This ensures consistency, readability, and actionable write-ups.
+
+---
+
+## Issue Title Format
+
+```
+Incident: <short description> (<affected service>)
+```
+
+**Example:** `Incident: HTTP 5xx due to OutOfMemory in Cart API (Grubify Container App)`
+
+---
+
+## Issue Body Template
+
+Use this exact markdown structure for the issue body:
+
+````markdown
+# Incident Report: <short description>
+
+- **Incident ID:** `<incident-id or alert correlation ID>`
+- **Service:** Azure Container Apps — `<container-app-name>` (rg: `<resource-group>`)
+- **Subscription:** `<subscription-id>`
+- **FQDN:** `<app-fqdn>`
+- **Active revision:** `<revision-name>` (100% traffic)
+
+## Summary
+
+<2-3 sentences describing what happened, what error was observed, and the symptoms.>
+
+## Impact
+
+- <User-facing impact, e.g., "API errors (5xx) on Cart endpoint during the spike window">
+- <Secondary impacts, e.g., "Failed cart operations for affected users">
+
+## Timeline (UTC)
+
+- **~HH:MM:** <First sign / metric anomaly>
+- **~HH:MM:** <Error escalation or alert fired>
+- **~HH:MM:** <Peak or notable event>
+
+## Evidence
+
+### Console logs (active revision)
+
+```
+<paste relevant error logs, stack traces>
+```
+
+### Traffic and Response Time
+
+<Use ExecutePythonCode to generate a chart of request count and response time over the investigation window. Attach the chart image.>
+
+### Metrics snapshot (Azure Monitor)
+
+- **Requests** (5m bins): <values at key timestamps>
+- **ResponseTime avg:** <peak value>
+- **RestartCount:** <value>
+- **MemoryPercentage:** <value and interpretation>
+- **UsageNanoCores:** <value if relevant>
+
+## Root Cause
+
+<1-2 sentences explaining the technical root cause. Reference the specific code path, controller, or component.>
+
+## Remediation
+
+- **Code:** <code-level fix, e.g., "Implement bounded cache or move to persistent store">
+- **Defensive:** <validation/throttling, e.g., "Add payload size limits and rate limiting">
+- **Platform:** <infrastructure fix, e.g., "Increase memory limit, add memory-based autoscale">
+- **Observability:** <monitoring improvements, e.g., "Add alert for OOM exceptions">
+
+## Action Items
+
+| # | Action | Priority |
+|---|--------|----------|
+| 1 | <specific fix> | High |
+| 2 | <test to add> | Medium |
+| 3 | <config change> | Medium |
+| 4 | <monitoring improvement> | Low |
+
+## References
+
+- Container App: `<full ARM resource ID>`
+- Log Analytics Workspace ID: `<workspace GUID>`
+- App Insights: `<full ARM resource ID>`
+````
+
+---
+
+## Labels to Apply
+
+Based on classification, apply these labels to the GitHub issue:
+
+| Condition | Labels |
+|-----------|--------|
+| Any bug | `bug` |
+| API-related | `api-bug` |
+| Frontend-related | `frontend-bug` |
+| Memory leak / OOM | `memory-leak` |
+| Critical or high severity | `severity-high` |
+| Medium severity | `severity-medium` |
+| Performance degradation | `performance` |
+
+---
+
+## Charts and Visual Evidence
+
+When generating evidence, use `ExecutePythonCode` to create charts:
+- Plot **Requests** and **ResponseTime** over time (dual-axis line chart)
+- Plot **MemoryPercentage** or **WorkingSetBytes** if memory-related
+- Use clear titles, axis labels, and timestamps in UTC
+- Save charts as PNG and attach to the issue
+
+---
+
+## Tips for Quality Incident Reports
+
+1. **Be specific** — include actual metric values, timestamps, and resource IDs
+2. **Include stack traces** — paste the full exception with file:line references
+3. **Show before/after** — compare the anomaly window to the normal baseline
+4. **Actionable items** — every report must end with concrete next steps
+5. **Link resources** — include full ARM resource IDs for quick portal navigation

--- a/samples/hands-on-lab/lab/skillable-instructions.md
+++ b/samples/hands-on-lab/lab/skillable-instructions.md
@@ -1,0 +1,647 @@
+# Azure SRE Agent Hands-On Lab
+
+Welcome, @lab.User.FirstName! In this lab you will deploy an **Azure SRE Agent** connected to a sample application, watch it diagnose and remediate issues autonomously, and explore three personas: **IT Operations**, **Developer**, and **Workflow Automation**.
+
+**Estimated time:** 60 minutes
+
+---
+
+## Lab Environment
+
+| Resource | Value |
+|:---------|:------|
+| **Azure Portal** | @lab.CloudPortal.SignInLink |
+| **Username** | ++@lab.CloudPortalCredential(User1).Username++ |
+| **Password** | ++@lab.CloudPortalCredential(User1).Password++ |
+| **Subscription ID** | ++@lab.CloudSubscription.Id++ |
+
+---
+
+### Optional: GitHub Integration
+
+> [!Note] The **core lab** (IT Persona — incident detection, log analysis, remediation) works **without GitHub**. If you have a GitHub account, entering your PAT and username below unlocks two bonus scenarios: source code root cause analysis and automated issue triage.
+
+If you want to use GitHub:
+
+1. **Fork the Grubify repo** — Open a **Git Bash** terminal and run:
+
+    ```
+    gh auth login
+    gh repo fork dm-chelupati/grubify --clone=false
+    ```
+
+    Follow the browser prompts to sign in. Select **HTTPS** when asked.
+
+2. Enter your GitHub username below:
+
+**GitHub Username:** @lab.TextBox(githubUser)
+
+3. **Create a token for the SRE Agent** — Click this link (it pre-fills the settings):
+
+    [Create token with repo scope](https://github.com/settings/tokens/new?scopes=repo&description=SRE+Agent+Lab)
+
+    Click **Generate token** at the bottom and paste it below:
+
+**GitHub PAT:** @lab.MaskedTextBox(githubPat)
+
+> [!Alert] The PAT is only used by the SRE Agent's GitHub MCP connector — it's how the agent creates issues and searches code in your forked repo.
+
+===
+
+# Part 1: Deploy the Environment
+
+In this section you will clone the lab repository and deploy all Azure resources with a single command. The deployment creates:
+
+- **Grubify** — A sample food ordering app on Azure Container Apps
+- **Azure SRE Agent** — Connected to the app's resource group with Azure Monitor
+- **Knowledge Base** — HTTP error runbooks and app architecture documentation
+- **Alert Rules** — Azure Monitor alerts for HTTP 5xx errors and error log spikes
+- **Subagent** — Incident handler with search memory and log analysis tools
+- *(If GitHub PAT provided)* GitHub MCP connector, code-analyzer, and issue-triager subagents
+
+> [!Knowledge] Architecture Overview
+>
+> ```
+> ┌──────────────────────────────────────────────────────────────┐
+> │                    Azure Resource Group                      │
+> │                                                              │
+> │  ┌──────────────┐    alerts     ┌────────────────────────┐   │
+> │  │  Grubify App  │─────────────▶│   Azure Monitor         │   │
+> │  │ (Container    │              │   Alert Rules            │   │
+> │  │  Apps)        │              └──────────┬─────────────┘   │
+> │  └──────────────┘                         │ auto-flow        │
+> │                                           ▼                  │
+> │  ┌──────────────┐              ┌───────────────────────────┐ │
+> │  │ Log Analytics │◄────logs────│      Azure SRE Agent      │ │
+> │  │ + App Insights│              │                           │ │
+> │  └──────────────┘              │  ┌─────────────────────┐  │ │
+> │                                │  │  Knowledge Base      │  │ │
+> │  ┌──────────────┐              │  │  • http-500-errors   │  │ │
+> │  │ Managed       │              │  │  • app architecture  │  │ │
+> │  │ Identity      │              │  └─────────────────────┘  │ │
+> │  │ (Reader RBAC) │              │                           │ │
+> │  └──────────────┘              │  ┌─────────────────────┐  │ │
+> │                                │  │  Subagents           │  │ │
+> │                                │  │  • incident-handler  │  │ │
+> │                                │  │  • (code-analyzer)   │  │ │
+> │                                │  │  • (issue-triager)   │  │ │
+> │                                │  └─────────────────────┘  │ │
+> │                                │                           │ │
+> │                                │  ┌─────────────────────┐  │ │
+> │                                │  │  GitHub MCP (opt.)  ─┼──┼─▶ GitHub
+> │                                │  └─────────────────────┘  │ │
+> │                                └───────────────────────────┘ │
+> └──────────────────────────────────────────────────────────────┘
+> ```
+
+---
+
+### Step 1: Sign in to Azure
+
+1. [] Open a **Git Bash** terminal on the lab VM (search for "Git Bash" in the Start menu, or open VS Code and select Git Bash as the terminal).
+
+1. [] Sign in to Azure CLI:
+
+    ```
+    az login
+    ```
+
+    Follow the browser prompts using the lab credentials shown above.
+
+1. [] Set the subscription:
+
+    ```
+    az account set --subscription "@lab.CloudSubscription.Id"
+    ```
+
+---
+
+### Step 2: Clone the lab repository
+
+1. [] Clone the lab repo and navigate into it:
+
+    ```
+    git clone https://github.com/dm-chelupati/sre-agent-lab.git
+    cd sre-agent-lab
+    ```
+
+---
+
+### Step 3: Deploy with azd up
+
+1. [] Initialize the azd environment:
+
+    ```
+    azd env new sre-lab
+    ```
+
+1. [] *(Only if you entered GitHub details above)* Set GitHub variables:
+
+    ```
+    azd env set GITHUB_PAT "@lab.Variable(githubPat)"
+    azd env set GITHUB_USER "@lab.Variable(githubUser)"
+    ```
+
+> [!Hint] If you did **not** enter GitHub details, skip the commands above. The core lab works without GitHub.
+
+1. [] Deploy everything with a single command:
+
+    ```
+    azd up
+    ```
+
+1. [] When prompted, select:
+    - **Subscription**: Your lab subscription
+    - **Location**: ++eastus2++
+
+> [!Alert] Deployment takes approximately **8-12 minutes**. The command provisions Azure resources via Bicep, deploys the Grubify app, then runs a post-provision script that configures the SRE Agent with knowledge base, subagents, and response plans.
+
+1. [] Wait for the deployment to complete. You will see a success banner:
+
+    ```
+    ✅ SRE Agent Lab Setup Complete!
+    SRE Agent Portal:  https://sre.azure.com
+    Grubify App:       https://ca-grubify-xxxxx.eastus2.azurecontainerapps.io
+    ```
+
+1. [] Copy the **Grubify App URL** from the output and paste it here for quick reference:
+
+    **Grubify URL:** @lab.TextBox(grubifyUrl)
+
+===
+
+# Part 2: Explore the SRE Agent
+
+Before diving into specific scenarios, explore what `azd up` configured for you.
+
+---
+
+### Step 1: Open the SRE Agent Portal
+
+1. [] Open <[sre.azure.com](https://sre.azure.com)> in a browser and sign in with your lab credentials.
+
+1. [] Find your agent in the list and click on it.
+
+> [!Knowledge] The SRE Agent was created via Bicep as a `Microsoft.App/agents` resource with:
+> - **Autonomous mode** — the agent takes actions without waiting for approval
+> - **Azure Monitor integration** — alerts from your resource group flow to the agent automatically
+> - **Managed Identity** — with Reader, Monitoring Reader, and Log Analytics Reader roles on the resource group
+
+---
+
+### Step 2: Explore the Knowledge Base
+
+1. [] Click **Builder** in the left sidebar.
+
+1. [] Select **Knowledge base**.
+
+1. [] Verify you see uploaded files:
+
+    | File | Purpose |
+    |:-----|:--------|
+    | **http-500-errors.md** | HTTP error troubleshooting runbook with KQL queries |
+    | **grubify-architecture.md** | App architecture, endpoints, scaling config |
+    | **github-issue-triage.md** | Grubify app issue triage runbook (if GitHub configured) |
+
+> [!Note] These files were uploaded automatically by the post-provision script. The agent references YOUR runbooks during investigations — not generic advice.
+
+---
+
+### Step 3: Explore the Subagents
+
+1. [] Click **Builder** → **Subagent builder**.
+
+1. [] You should see the **incident-handler** subagent with:
+    - **Autonomy:** Autonomous
+    - **Tools:** SearchMemory, RunAzCliReadCommands, QueryLogAnalyticsByWorkspaceId (+ github-mcp/* if GitHub was configured)
+
+1. [] Click on **incident-handler** to see its system prompt and tool assignments.
+
+> [!Knowledge] If you provided a GitHub PAT, you'll also see **code-analyzer** and **issue-triager** subagents on the canvas.
+
+---
+
+### Step 4: Explore Connectors (if GitHub configured)
+
+1. [] Click **Builder** → **Connectors**.
+
+1. [] If you provided a GitHub PAT, you should see **github-mcp** with a green **Connected** status.
+
+> [!Hint] If you didn't provide a GitHub PAT and want to add GitHub now, run:
+>
+> ```
+> export GITHUB_PAT=<your-pat>
+> ./scripts/setup-github.sh
+> ```
+
+---
+
+### Step 5: Verify the Grubify App
+
+1. [] In your terminal, check the app is running:
+
+    ```
+    curl https://@lab.Variable(grubifyUrl)/api/restaurants
+    ```
+
+    You should see a JSON response with weather data.
+
+---
+
+### Step 6: Chat with Your Agent
+
+Before we break things, try a few prompts to see the agent in action.
+
+> [!Alert] Always start a **new chat thread** for each prompt — do not use the welcome thread. Click the **+ New Chat** button in the SRE Agent portal.
+
+1. [] Try one of these prompts (pick either one):
+
+    **Option A** — Ask about deployed resources:
+    ```
+    How many container apps are deployed for the Grubify application?
+    List them with their endpoints.
+    ```
+
+    **Option B** — Ask for the frontend URL:
+    ```
+    What is the public endpoint URL for the Grubify frontend
+    container app?
+    ```
+
+    The agent should find the container apps and return their URLs. Copy the frontend URL from the response.
+
+1. [] Open the Grubify app in your browser:
+
+    - [] Click the frontend URL the agent gave you
+    - [] You should see the Grubify food ordering app with restaurants
+    - [] Click on a restaurant, browse the menu
+    - [] **Add an item to your cart** — it should work fine
+    - [] This is the app working normally — remember this for when we break it!
+
+1. [] Ask about the app's API routes using the knowledge base:
+
+    ```
+    Using the grubify-architecture document in the knowledge base,
+    what are the API routes for the Grubify backend API?
+    Give me a curl command to try one of them.
+    ```
+
+    The agent should search the knowledge base, return the API endpoints (restaurants, food items, orders, cart), and give you a curl command. Try running it in your terminal!
+
+> [!Knowledge] These prompts demonstrate the agent's built-in tools: `RunAzCliReadCommands` for Azure resource queries and `SearchMemory` for knowledge base search. All configured automatically by `azd up`.
+
+===
+
+# Part 3: IT Persona — Incident Detection & Remediation
+
+> [!Knowledge] **This is the core lab — no GitHub required.**
+
+**Scenario:** You are an SRE/Ops engineer. The Grubify application starts experiencing memory pressure from a cart API memory leak. Azure Monitor fires alerts for high memory usage and container restarts. The SRE Agent automatically investigates using logs, knowledge base, and memory — then remediates the issue.
+
+```
+                  IT Persona Flow
+                  ================
+
+  You (run script)                           SRE Agent
+  ──────────────                             ─────────
+  1. Flood cart API ———————▶ Grubify App ————▶ Memory grows
+     (POST /api/cart)                │              │
+                                     │              ▼
+                                     │        OOM / 500 errors
+                                     │
+                                     ▼
+                              Azure Monitor ————▶ Alerts fire:
+                                     │            • High memory (>80%)
+                                     │            • Container restarts
+                                     │            • HTTP 5xx errors
+                                     ▼ (auto-flow)
+                               SRE Agent investigates:
+                                 ├── Searches memory for similar incidents
+                                 ├── Queries Log Analytics (KQL)
+                                 │    • Memory metrics over time
+                                 │    • OOM / restart events
+                                 │    • Error logs + stack traces
+                                 ├── Checks knowledge base (runbook)
+                                 ├── Applies remediation (restart/scale)
+                                 └── Shows investigation summary
+```
+
+---
+
+### Step 1: Break the App
+
+1. [] Run the fault injection script:
+
+    ```
+    ./scripts/break-app.sh
+    ```
+
+    This script:
+    - Floods the `/api/cart/demo-user/items` endpoint with rapid POST requests
+    - Each request adds items to an in-memory cart, causing memory to grow
+    - Eventually the container hits its 1Gi memory limit → OOM kill → restarts
+    - Azure Monitor fires alerts for high memory, container restarts, and HTTP errors
+
+> [!Alert] After running the script, **wait 5-8 minutes** for Azure Monitor to fire the alert and the SRE Agent to pick it up. The memory leak takes a few minutes to build up enough pressure to trigger alerts.
+
+1. [] While waiting, go back to the Grubify frontend app in your browser:
+
+    - [] Try adding an item to your cart
+    - [] Notice the app is **slow, unresponsive, or returning errors**
+    - [] This confirms the app is broken — the memory leak is causing problems
+    - [] Compare this to how smoothly it worked in Step 6!
+
+---
+
+### Step 2: Watch the Agent Investigate
+
+1. [] Go back to the SRE Agent portal at <[sre.azure.com](https://sre.azure.com)>.
+
+1. [] Click **Activities** → **Incidents** in the left sidebar.
+
+1. [] A new incident should appear — the Azure Monitor alert for HTTP 5xx errors on Grubify.
+
+1. [] Click on the incident to see the agent's investigation thread.
+
+1. [] Observe the agent's workflow:
+
+    - [] **Memory search**: The agent searches for similar past incidents
+    - [] **Log analysis**: Queries Log Analytics for memory pressure indicators, OOM events, and error logs
+    - [] **Metrics check**: Analyzes container memory usage trends (WorkingSetBytes rising over time)
+    - [] **Knowledge base**: References the http-500-errors.md runbook for memory leak diagnosis steps
+    - [] **Root cause**: Identifies the `/api/cart` endpoint accumulating data without eviction
+    - [] **Remediation**: Takes corrective action (restart container revision, scale up memory)
+    - [] **Summary**: Provides root cause analysis with evidence (memory timeline, error logs, KQL queries)
+
+---
+
+### Step 3: Examine the Investigation Details
+
+1. [] In the agent's investigation thread, look for:
+
+    - [] **Sources** showing references to your knowledge base files
+    - [] KQL queries the agent executed against Log Analytics
+    - [] Timeline of events (when errors started, when remediation was applied)
+    - [] Root cause conclusion
+
+> [!Knowledge] **What just happened?** The entire investigation was autonomous. The response plan routes all Azure Monitor alerts from the managed resource group to the `incident-handler` subagent. That subagent used KQL queries from the knowledge base runbook, searched memory for patterns, checked metrics, and applied remediation — then created a GitHub issue documenting everything. All without human intervention.
+
+---
+
+### Step 4 (Optional): Ask the Agent to Mitigate
+
+> [!Knowledge] This step is optional. If you're short on time, skip ahead to **Part 4**. You can always come back to try mitigation later.
+
+1. [] In the same incident thread, type the following in the chat:
+
+    ```
+    Can you mitigate this issue?
+    ```
+
+1. [] Watch the agent take action:
+    - [] **Mitigate**: The agent may restart the container app revision or scale out replicas to recover
+    - [] **Verify**: Checks the app endpoints to confirm it's healthy again
+
+1. [] Once the agent confirms the app is back, verify it yourself:
+
+    ```
+    curl https://@lab.Variable(grubifyUrl)/api/restaurants
+    ```
+
+    - [] You should get a JSON response — the app is healthy again!
+
+---
+
+### Step 5: Break the App Again (for Part 4)
+
+> [!Alert] Run the break script again to generate fresh error traffic for the Developer persona scenario in Part 4.
+
+```
+./scripts/break-app.sh
+```
+
+This sends another burst of requests to the cart API, triggering new 500 errors and memory pressure that the code-analyzer subagent will investigate.
+
+===
+
+# Part 4: Developer Persona — Deep Root Cause with Source Code
+
+> [!Alert] **This section requires a GitHub PAT.** If you did not provide one during setup, skip to **Part 6: Review & Cleanup**. You can also add GitHub now by running: `export GITHUB_PAT=<pat> && ./scripts/setup-github.sh`
+
+**Scenario:** The incident-handler subagent (Part 3) created a GitHub issue using only log analysis. Now use the **code-analyzer** subagent to create a RICHER issue that includes source code references. Compare the two issues to see the value of connecting source code.
+
+> [!Knowledge] **What's different between the two subagents?**
+>
+> | | incident-handler (Part 3) | code-analyzer (Part 4) |
+> |:--|:--|:--|
+> | **Log analysis** | ✅ | ✅ |
+> | **Knowledge base** | ✅ | ✅ |
+> | **Source code search** | ❌ Told NOT to search code | ✅ Searches GitHub repo |
+> | **File:line references** | ❌ | ✅ |
+> | **Code fix suggestions** | ❌ | ✅ |
+> | **GitHub issue detail** | Basic (log evidence only) | Rich (code + logs + fix) |
+
+---
+
+### Step 1: Investigate with Source Code
+
+1. [] In the SRE Agent portal, start a **new chat** by clicking the **+ New Chat** button.
+
+1. [] Type `/agent` in the chat box and select the **code-analyzer** subagent from the dropdown.
+
+1. [] Send the following prompt:
+
+    ```
+    The Grubify API is not responding — specifically the "Add to Cart" 
+    is failing. Can you investigate, find the root cause in the source 
+    code and create a GitHub issue with your detailed findings?
+    ```
+
+1. [] Observe the ADDITIONAL steps compared to the incident-handler:
+    - [] **Source code search**: Searches the Grubify repo for cart API implementation
+    - [] **Code correlation**: Maps error logs to specific functions and files
+    - [] **File:line references**: Points to the exact code causing the memory leak
+    - [] **Fix suggestion**: Proposes a code change (e.g., add cache eviction, size limit)
+
+---
+
+### Step 2: Compare the Two GitHub Issues
+
+1. [] Go to [github.com/@lab.Variable(githubUser)/grubify/issues](https://github.com/@lab.Variable(githubUser)/grubify/issues).
+
+1. [] Compare the two issues side by side:
+
+    - [] **Issue from incident-handler** (Part 3): Log-based analysis — "Memory pressure detected, container restarted, KQL evidence shows error spike at timestamp X"
+    - [] **Issue from code-analyzer** (Part 4): Same log evidence PLUS — "Root cause in `CartService.cs` line 45: in-memory dictionary grows unbounded. Suggested fix: add LRU eviction or max size limit"
+
+> [!Knowledge] **The delta is clear:** Adding source code search to the investigation takes the agent from "what happened" (logs) to "why it happened and how to fix it" (code). Same tools, different instructions — the code-analyzer subagent is instructed to search source code and provide code-level fixes, producing significantly richer findings.
+
+---
+
+### Step 3: Ask the Agent to Mitigate
+
+1. [] Start a **new chat** by clicking the **+ New Chat** button.
+
+1. [] Ask the agent to fix the issue:
+
+    ```
+    Can you mitigate the Grubify cart API memory leak issue?
+    ```
+
+1. [] Watch the agent:
+    - [] **Mitigate**: The agent may restart the container app or scale out replicas
+    - [] **Verify** the endpoints are responding
+
+1. [] Confirm the app is back yourself:
+
+    ```
+    curl https://@lab.Variable(grubifyUrl)/api/restaurants
+    ```
+
+    - [] You should get a JSON response — the app is healthy again!
+
+===
+
+# Part 5: Workflow Automation — Issue Triage
+
+> [!Alert] **This section requires a GitHub PAT.** If you did not provide one during setup, skip to **Part 6: Review & Cleanup**.
+
+**Scenario:** During setup, `azd up` created 5 sample customer-reported issues in `@lab.Variable(githubUser)/grubify` — these simulate real user complaints like "App crashes when adding items to cart" and "Can't place an order." Now use the **issue-triager** subagent to triage those issues — classify them, add labels, and post a structured comment. A scheduled task runs this automatically every 12 hours.
+
+---
+
+### Step 1: Check the Customer Issues
+
+1. [] Go to [github.com/@lab.Variable(githubUser)/grubify/issues](https://github.com/@lab.Variable(githubUser)/grubify/issues).
+
+1. [] You should see several issues — look for the ones with **[Customer Issue]** in the title. These are the simulated customer reports that need triaging.
+
+---
+
+### Step 2: Run the Triage Task
+
+1. [] In the SRE Agent portal, go to **Builder → Scheduled tasks**.
+
+1. [] Find the **triage-grubify-issues** task.
+
+1. [] Click **Run task now** to trigger it immediately.
+
+1. [] Watch the agent:
+    - [] Lists open issues from the repository
+    - [] Reads each issue and classifies it (Bug, Performance, Feature Request, Question)
+    - [] Adds labels (bug, api-bug, memory-leak, severity-high, etc.)
+    - [] Posts a triage comment starting with "🤖 **Grubify SRE Agent Bot**"
+
+---
+
+### Step 3: Check the Triage Comments
+
+1. [] Once the task completes, go to [github.com/@lab.Variable(githubUser)/grubify/issues](https://github.com/@lab.Variable(githubUser)/grubify/issues).
+
+1. [] Open one of the **[Customer Issue]** issues (e.g., "App crashes when adding items to cart").
+
+1. [] Scroll down to the comments section. You should see a triage comment:
+
+    - [] Comment starts with "🤖 **Grubify SRE Agent Bot**"
+    - [] Classification: Bug, Performance, Feature Request, or Question
+    - [] Labels applied: `bug`, `api-bug`, `severity-high`, `needs-more-info`, etc.
+    - [] Status line at the end (e.g., "Ready for investigation" or "Waiting for info")
+
+1. [] Check a few other [Customer Issue] issues to see how different types were classified:
+    - [] The cart crash → Bug (api-bug, severity-high)
+    - [] Slow menu page → Performance
+    - [] Restaurant search → Feature Request
+    - [] How to clear cart → Question
+
+> [!Knowledge] The triager only processes issues with **[Customer Issue]** in the title — it skips the detailed incident reports created by the incident-handler and code-analyzer (since those are already fully analyzed). The scheduled task runs automatically every 12 hours, so new customer issues get triaged without manual intervention.
+
+===
+
+# Part 6: Review & Cleanup
+
+## What You Learned
+
+| Persona | What the Agent Did | Key Capabilities |
+|:--------|:-------------------|:-----------------|
+| **IT Operations** | Detected alert → investigated logs + KB → remediated → summarized | Azure Monitor, Knowledge base, Search memory, Autonomous mode |
+| **Developer** | Searched source code → correlated logs to code → suggested fixes | GitHub MCP, Code search, file:line references |
+| **Workflow Automation** | Triaged issues → classified → labeled → commented | GitHub MCP tools, Runbook-driven automation |
+
+---
+
+## What azd up Automated
+
+Everything below was configured automatically when you ran `azd up`:
+
+- [] SRE Agent resource (Bicep: `Microsoft.App/agents`)
+- [] Managed Identity with Reader + Monitoring Reader + Log Analytics Reader RBAC (Bicep)
+- [] Log Analytics Workspace + Application Insights (Bicep)
+- [] Grubify Container App with external ingress (Bicep)
+- [] Azure Monitor alert rules — HTTP 5xx metric + error log alerts (Bicep)
+- [] Knowledge base files uploaded (post-provision script)
+- [] Incident handler subagent created (post-provision script)
+- [] Incident response plan created (post-provision script)
+- [] *(If GitHub PAT)* GitHub MCP connector, code-analyzer, issue-triager, sample customer issues (post-provision script)
+
+---
+
+## Key SRE Agent Concepts
+
+> [!Knowledge] Quick reference for the concepts you explored:
+>
+> - **[Managed Resources](https://sre.azure.com/docs/capabilities/incident-response)**: Resource group IDs the agent monitors — Azure Monitor alerts from these RGs flow automatically
+> - **[Knowledge Base](https://sre.azure.com/docs/concepts/memory)**: Your team's runbooks, uploaded as files — the agent references them during investigations
+> - **[Memory](https://sre.azure.com/docs/concepts/memory)**: The agent learns from every conversation — past incidents, user memories, and knowledge base are all searchable via SearchMemory
+> - **[Subagents](https://sre.azure.com/docs/concepts/subagents)**: Specialized agents with specific tools and instructions for different tasks — invoke with `/agent` in chat
+> - **[Agent Identity](https://sre.azure.com/docs/concepts/permissions)**: A managed identity assigned to the agent, granting it Reader/Monitoring/Log Analytics access to your Azure resources
+> - **[Connectors](https://sre.azure.com/docs/concepts/connectors)**: External tool integrations (GitHub, Datadog, etc.) using the Model Context Protocol
+> - **[Response Plans](https://sre.azure.com/docs/capabilities/incident-response)**: Rules that match incoming alerts to subagents based on severity and title patterns
+> - **[Scheduled Tasks](https://sre.azure.com/docs/capabilities/scheduled-tasks)**: Cron-based automation that runs a subagent on a schedule (e.g., triage issues every 12 hours)
+> - **[Autonomous Mode](https://sre.azure.com/docs/concepts/subagents)**: The agent takes actions without requiring human approval
+
+---
+
+## Cleanup
+
+1. [] Tear down all Azure resources:
+
+    ```
+    azd down --purge
+    ```
+
+1. [] Delete the SRE Agent resource (not removed by azd down):
+
+    ```
+    az resource delete --ids $(az resource list --resource-group rg-$(azd env get-value AZURE_ENV_NAME) --resource-type Microsoft.App/agents --query "[0].id" -o tsv) 2>/dev/null
+    ```
+
+1. [] Delete the resource group if it still exists:
+
+    ```
+    az group delete --name rg-$(azd env get-value AZURE_ENV_NAME) --yes --no-wait
+    ```
+
+> [!Alert] This **permanently deletes** all Azure resources. Make sure you have saved any notes or screenshots before proceeding.
+
+> [!Note] `azd down` does not currently recognize the `Microsoft.App/agents` resource type, so the SRE Agent must be deleted separately.
+
+===
+
+# Congratulations! 🎉
+
+You have successfully deployed and explored Azure SRE Agent across three personas:
+
+1. **IT Operations** — Autonomous incident detection, investigation, and remediation using logs and knowledge base
+2. **Developer** — Source code root cause analysis with file:line references
+3. **Workflow Automation** — Automated GitHub issue triage following a custom runbook
+
+All of this was set up with a single `azd up` command.
+
+## Resources
+
+- [Azure SRE Agent Documentation](https://sre.azure.com/docs)
+- [Azure SRE Agent Portal](https://sre.azure.com)
+- [Grubify Sample App](https://github.com/dm-chelupati/grubify)
+- [Lab Source Code](https://github.com/dm-chelupati/sre-agent-lab)
+
+**Thank you for completing this lab, @lab.User.FirstName!**

--- a/samples/hands-on-lab/scripts/break-app.sh
+++ b/samples/hands-on-lab/scripts/break-app.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# =============================================================================
+# Break App Script — Simulates memory leak on Grubify
+#
+# This script:
+#   1. Checks app health
+#   2. Floods the cart API with rapid POST requests to cause memory leak
+#   3. Azure Monitor detects memory pressure / OOM / HTTP errors
+#   4. The SRE Agent picks up the alert and begins investigation
+#
+# The /api/cart/demo-user/items endpoint accumulates cart items in memory.
+# Rapid repeated calls cause memory to grow until the container OOMs or
+# starts returning 500 errors from memory pressure.
+# =============================================================================
+set -e
+
+# Configuration
+REQUEST_COUNT=${2:-200}
+SLEEP_INTERVAL=${3:-0.5}
+
+# Get Container App URL from azd environment or argument
+APP_URL="${1:-}"
+if [ -z "$APP_URL" ]; then
+  APP_URL=$(azd env get-values 2>/dev/null | grep "^CONTAINER_APP_URL=" | cut -d'=' -f2 | tr -d '"')
+fi
+
+if [ -z "$APP_URL" ]; then
+  echo "Error: Could not determine Grubify URL."
+  echo "Usage: ./scripts/break-app.sh [https://your-app-url] [request-count] [sleep-seconds]"
+  echo "   Or: Run from the lab directory after 'azd up'"
+  exit 1
+fi
+
+echo ""
+echo "============================================="
+echo "  🔥 Breaking the Grubify App (Memory Leak)"
+echo "============================================="
+echo ""
+echo "  Target:    ${APP_URL}"
+echo "  Requests:  ${REQUEST_COUNT}"
+echo "  Interval:  ${SLEEP_INTERVAL}s"
+echo ""
+
+# Step 1: Check app is healthy first
+echo "Step 1: Checking app health..."
+HEALTH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${APP_URL}/health" 2>/dev/null || echo "000")
+if [ "$HEALTH_STATUS" = "200" ]; then
+  echo "  ✓ App is healthy (HTTP ${HEALTH_STATUS})"
+else
+  echo "  ⚠ App returned HTTP ${HEALTH_STATUS} — proceeding anyway"
+fi
+echo ""
+
+# Step 2: Flood cart API to cause memory leak
+echo "Step 2: Flooding cart API to simulate memory leak..."
+echo "  Sending POST requests to /api/cart/demo-user/items"
+echo "  Each request adds items to an in-memory cart, causing memory growth."
+echo ""
+ERROR_COUNT=0
+SUCCESS_COUNT=0
+for i in $(seq 1 $REQUEST_COUNT); do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "${APP_URL}/api/cart/demo-user/items" \
+    -H "Content-Type: application/json" \
+    -d '{"foodItemId":1,"quantity":1}' 2>/dev/null || echo "000")
+  if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+    SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+  else
+    ERROR_COUNT=$((ERROR_COUNT + 1))
+  fi
+  # Print progress every 25 requests
+  if [ $((i % 25)) -eq 0 ]; then
+    echo "  $(date '+%H:%M:%S') — Sent ${i}/${REQUEST_COUNT} requests (${SUCCESS_COUNT} ok, ${ERROR_COUNT} errors)"
+  fi
+  sleep $SLEEP_INTERVAL
+done
+
+echo ""
+echo "  Results: ${SUCCESS_COUNT} successes, ${ERROR_COUNT} errors out of ${REQUEST_COUNT} requests"
+echo ""
+
+# Step 3: Verify app state
+echo "Step 3: Checking app state after load..."
+FINAL_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${APP_URL}/health" 2>/dev/null || echo "000")
+echo "  Health check: HTTP ${FINAL_STATUS}"
+MENU_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${APP_URL}/api/menu" 2>/dev/null || echo "000")
+echo "  Menu API:     HTTP ${MENU_STATUS}"
+echo ""
+
+echo "============================================="
+echo "  ✅ Memory leak triggered!"
+echo "============================================="
+echo ""
+echo "  What happens next:"
+echo "    1. Memory pressure builds in the container (~2-5 minutes)"
+echo "    2. Azure Monitor detects high memory / OOM / HTTP errors"
+echo "    3. An alert fires and flows to your SRE Agent"
+echo "    4. The agent starts investigating automatically"
+echo "    5. Open https://sre.azure.com → Incidents to watch"
+echo ""
+echo "  ⏱  Wait 5-8 minutes, then check the SRE Agent portal."
+echo ""
+echo "  The agent will find:"
+echo "    • Memory spike in container metrics"
+echo "    • Cart API accumulating items without cleanup"
+echo "    • Connection to /api/cart/demo-user/items in logs"
+echo "    • Root cause in source code (in-memory cart with no eviction)"
+echo ""

--- a/samples/hands-on-lab/scripts/create-sample-issues.sh
+++ b/samples/hands-on-lab/scripts/create-sample-issues.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# =============================================================================
+# Create Sample Customer Issues for Grubify App
+#
+# Creates 5 realistic customer-reported issues with [Customer Issue] prefix.
+# These simulate real user complaints — the issue-triager will classify,
+# label, and comment on them.
+#
+# Requires: GITHUB_PAT (or GITHUB_PAT_VALUE) with 'repo' scope
+#
+# Usage:
+#   export GITHUB_PAT=<your-github-pat>
+#   ./scripts/create-sample-issues.sh [owner/repo]
+# =============================================================================
+set -uo pipefail
+
+REPO="${1:-${GITHUB_REPO:-}}"
+PAT="${GITHUB_PAT:-${GITHUB_PAT_VALUE:-}}"
+
+if [ -z "$REPO" ]; then
+  echo "Usage: $0 <owner/repo>"
+  echo "  or: export GITHUB_REPO=owner/repo && $0"
+  exit 1
+fi
+
+if [ -z "$PAT" ]; then
+  echo "Error: GITHUB_PAT not set"
+  exit 1
+fi
+
+API="https://api.github.com/repos/${REPO}/issues"
+AUTH="Authorization: token ${PAT}"
+
+create_issue() {
+  local title="$1"
+  local body="$2"
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "$API" \
+    -H "$AUTH" \
+    -H "Content-Type: application/json" \
+    -d "{\"title\": \"$title\", \"body\": \"$body\"}")
+  if [ "$HTTP_CODE" = "201" ]; then
+    echo "   ✅ $title"
+  else
+    echo "   ⚠️  HTTP $HTTP_CODE: $title"
+  fi
+}
+
+echo ""
+echo "📝 Creating sample customer issues in ${REPO}..."
+echo ""
+
+create_issue \
+  "[Customer Issue] App crashes when adding items to cart" \
+  "Hi, I'm trying to add items to my cart on the Grubify app but it keeps crashing. I get a server error after adding about 5-6 items quickly. The page just shows a generic error message.\\n\\nThis started happening today around 3pm. Can someone look into this?"
+
+create_issue \
+  "[Customer Issue] Menu page is loading very slowly" \
+  "The restaurants page is taking forever to load. It used to be instant but now it takes 10-15 seconds.\\n\\nI'm on a good internet connection so I don't think it's on my end. Is there something wrong with the server?"
+
+create_issue \
+  "[Customer Issue] Can't place an order - getting 500 error" \
+  "When I click Place Order I get an Internal Server Error. I've tried multiple times with different items. My cart has items in it but the order just won't go through.\\n\\nPlease fix this ASAP, I'm hungry!"
+
+create_issue \
+  "[Customer Issue] Feature request - add search for restaurants" \
+  "It would be great if I could search for restaurants by name or cuisine type instead of scrolling through the whole list.\\n\\nCan you add a search bar to the restaurants page?"
+
+create_issue \
+  "[Customer Issue] How do I clear my cart?" \
+  "I added some items to my cart by mistake and I can't figure out how to remove them. Is there a way to clear the cart or remove individual items? I don't see a delete button anywhere."
+
+echo ""
+echo "✅ Created 5 sample customer issues in ${REPO}"
+echo "   Run the triage scheduled task to classify them!"

--- a/samples/hands-on-lab/scripts/generate-pptx.py
+++ b/samples/hands-on-lab/scripts/generate-pptx.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Generate a clean, professional PowerPoint deck for the Azure SRE Agent MVP Lab Session."""
+
+from pptx import Presentation
+from pptx.util import Inches, Pt, Emu
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.enum.shapes import MSO_SHAPE
+
+prs = Presentation()
+prs.slide_width = Inches(13.333)
+prs.slide_height = Inches(7.5)
+
+# Colors
+DARK_BLUE = RGBColor(0x00, 0x33, 0x66)
+AZURE_BLUE = RGBColor(0x00, 0x78, 0xD4)
+WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+LIGHT_GRAY = RGBColor(0xF2, 0xF2, 0xF2)
+DARK_GRAY = RGBColor(0x33, 0x33, 0x33)
+ACCENT_GREEN = RGBColor(0x10, 0x7C, 0x10)
+ACCENT_ORANGE = RGBColor(0xFF, 0x8C, 0x00)
+
+def add_bg(slide, color):
+    bg = slide.background
+    fill = bg.fill
+    fill.solid()
+    fill.fore_color.rgb = color
+
+def add_text_box(slide, left, top, width, height, text, font_size=18, color=DARK_GRAY, bold=False, alignment=PP_ALIGN.LEFT):
+    txBox = slide.shapes.add_textbox(Inches(left), Inches(top), Inches(width), Inches(height))
+    tf = txBox.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = text
+    p.font.size = Pt(font_size)
+    p.font.color.rgb = color
+    p.font.bold = bold
+    p.alignment = alignment
+    return tf
+
+def add_para(tf, text, font_size=16, color=DARK_GRAY, bold=False, space_before=Pt(6)):
+    p = tf.add_paragraph()
+    p.text = text
+    p.font.size = Pt(font_size)
+    p.font.color.rgb = color
+    p.font.bold = bold
+    p.space_before = space_before
+    return p
+
+def add_shape_box(slide, left, top, width, height, fill_color, text="", font_size=14, font_color=WHITE):
+    shape = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(left), Inches(top), Inches(width), Inches(height))
+    shape.fill.solid()
+    shape.fill.fore_color.rgb = fill_color
+    shape.line.fill.background()
+    if text:
+        tf = shape.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = text
+        p.font.size = Pt(font_size)
+        p.font.color.rgb = font_color
+        p.font.bold = True
+        p.alignment = PP_ALIGN.CENTER
+        tf.paragraphs[0].space_before = Pt(4)
+    return shape
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 1: Title
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])  # blank
+add_bg(slide, DARK_BLUE)
+add_text_box(slide, 1, 1.5, 11, 1.5, "Azure SRE Agent", 54, WHITE, True, PP_ALIGN.CENTER)
+add_text_box(slide, 1, 3.2, 11, 1, "Your AI-Powered Operations Expert", 28, RGBColor(0xBB, 0xDD, 0xFF), False, PP_ALIGN.CENTER)
+add_text_box(slide, 1, 4.5, 11, 0.6, "Generally Available  —  March 10, 2026", 22, ACCENT_GREEN, True, PP_ALIGN.CENTER)
+add_text_box(slide, 1, 5.8, 11, 0.6, "MVP Hands-On Lab Session", 20, RGBColor(0x99, 0xBB, 0xDD), False, PP_ALIGN.CENTER)
+add_text_box(slide, 1, 6.5, 11, 0.5, "sre.azure.com", 16, RGBColor(0x77, 0x99, 0xBB), False, PP_ALIGN.CENTER)
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 2: The Problem
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, WHITE)
+add_text_box(slide, 0.8, 0.4, 11, 0.8, "Operations teams are drowning in toil", 36, DARK_BLUE, True)
+
+# Pain points
+pains = [
+    ("2am alerts", "Manual runbook execution, error-prone under pressure"),
+    ("5+ tool context-switching", "Logs → metrics → traces → code → wiki → Slack"),
+    ("Knowledge silos", "Procedures locked in senior engineers' heads"),
+    ("Triage backlogs", "Same classification work, every day, growing pile"),
+]
+y = 1.6
+for title, desc in pains:
+    add_shape_box(slide, 0.8, y, 0.4, 0.4, ACCENT_ORANGE)
+    add_text_box(slide, 1.5, y, 4, 0.4, title, 20, DARK_GRAY, True)
+    add_text_box(slide, 1.5, y + 0.4, 5, 0.4, desc, 14, RGBColor(0x66, 0x66, 0x66))
+    y += 1.1
+
+# Costs
+add_text_box(slide, 7.5, 1.6, 5, 0.5, "The cost", 22, DARK_BLUE, True)
+costs = [
+    "MTTR measured in hours, not minutes",
+    "Engineer burnout and attrition", 
+    "Customer satisfaction drops",
+    "80% of response = gathering data",
+]
+tf = add_text_box(slide, 7.5, 2.3, 5, 3, "", 16, DARK_GRAY)
+for c in costs:
+    add_para(tf, f"→  {c}", 17, DARK_GRAY, space_before=Pt(12))
+
+add_shape_box(slide, 2, 6.2, 9, 0.8, AZURE_BLUE, "What if an AI agent could handle the 80%?", 22, WHITE)
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 3: Introducing SRE Agent
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, WHITE)
+add_text_box(slide, 0.8, 0.4, 11, 0.8, "Introducing Azure SRE Agent", 36, DARK_BLUE, True)
+add_text_box(slide, 0.8, 1.2, 11, 0.6, "Your AI teammate that learns and grows with your team", 20, RGBColor(0x66, 0x66, 0x66))
+
+# Three pillars
+pillars = [
+    ("Connect", "Azure resources\nIncident platforms\nAny API via MCP", AZURE_BLUE),
+    ("Enhance", "Your runbooks\nYour architecture docs\nDomain subagents", ACCENT_GREEN),
+    ("Achieve", "Faster investigations\nAutomated triage\nReliable remediation", ACCENT_ORANGE),
+]
+x = 1.2
+for title, items, color in pillars:
+    add_shape_box(slide, x, 2.2, 3.3, 0.7, color, title, 24, WHITE)
+    add_text_box(slide, x, 3.1, 3.3, 2, items, 16, DARK_GRAY)
+    x += 3.8
+
+# Key differentiators
+diffs = [
+    "Not a chatbot — an autonomous agent that takes action",
+    "Not generic AI — uses YOUR runbooks, YOUR data, YOUR procedures",
+    "Not locked-in — connects to any tool via MCP",
+]
+y = 5.3
+for d in diffs:
+    add_text_box(slide, 1.2, y, 10, 0.4, f"✓  {d}", 17, DARK_GRAY, True)
+    y += 0.45
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 4: Four Superpowers
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, WHITE)
+add_text_box(slide, 0.8, 0.4, 11, 0.8, "Four Superpowers", 36, DARK_BLUE, True)
+
+powers = [
+    ("Autonomous\nIncident Response", "Alert → investigate → remediate\nautonomously, 24/7", "Lower MTTR\nfrom hours to minutes", AZURE_BLUE),
+    ("Lightning-Fast\nRoot Cause Analysis", "Correlates logs + metrics +\ntraces + code + deploys", "Actionable insights,\nnot data dumps", RGBColor(0x5B, 0x2C, 0x8B)),
+    ("Extensible\nAutomation", "Connect any tool via MCP\nBuild self-healing workflows", "Eliminate toil,\nfree up engineers", ACCENT_GREEN),
+    ("Conversational\nOperations", "Natural language + Python\nAsk questions, get evidence", "Anyone can\ninvestigate", ACCENT_ORANGE),
+]
+
+x = 0.5
+for title, what, outcome, color in powers:
+    add_shape_box(slide, x, 1.5, 3, 1.2, color, title, 16, WHITE)
+    add_text_box(slide, x, 2.9, 3, 1.2, what, 13, DARK_GRAY)
+    add_shape_box(slide, x, 4.3, 3, 0.9, LIGHT_GRAY, outcome, 13, DARK_GRAY)
+    x += 3.2
+
+add_text_box(slide, 0.8, 5.8, 11, 0.8, "Each superpower is demonstrated in today's lab", 18, AZURE_BLUE, True, PP_ALIGN.CENTER)
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 5: Three Personas
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, WHITE)
+add_text_box(slide, 0.8, 0.4, 11, 0.8, "Three Personas — What You'll Try Today", 36, DARK_BLUE, True)
+
+scenarios = [
+    ("IT Operations / SRE", 
+     '"Stop running runbooks at 3am"',
+     "Alert fires → agent auto-investigates\nusing your runbook → remediates\n→ creates GitHub issue with findings",
+     "You wake up to results,\nnot raw alerts",
+     AZURE_BLUE),
+    ("Developer", 
+     '"From what happened to why + how to fix"',
+     "Same investigation + source code\nsearch → finds exact file:line\n→ creates richer issue with fix",
+     "Compare two GitHub issues\n— see the delta",
+     RGBColor(0x5B, 0x2C, 0x8B)),
+    ("Workflow Automation", 
+     '"Triage isn\'t the job, it\'s the tax"',
+     "Agent triages GitHub issues:\nclassify → label → comment\nRuns on schedule, automatically",
+     "Stop sorting tickets.\nStart shipping.",
+     ACCENT_GREEN),
+]
+
+x = 0.5
+for title, quote, desc, outcome, color in scenarios:
+    add_shape_box(slide, x, 1.5, 3.8, 0.8, color, title, 18, WHITE)
+    add_text_box(slide, x + 0.1, 2.5, 3.6, 0.5, quote, 13, RGBColor(0x66, 0x66, 0x66))
+    add_text_box(slide, x + 0.1, 3.1, 3.6, 1.8, desc, 14, DARK_GRAY)
+    add_shape_box(slide, x, 5.2, 3.8, 0.9, LIGHT_GRAY, outcome, 14, DARK_GRAY)
+    x += 4.1
+
+add_text_box(slide, 0.8, 6.4, 11, 0.5, "Core lab (IT Ops) works without GitHub  •  Developer + Workflow are bonus scenarios with GitHub", 14, RGBColor(0x66, 0x66, 0x66), False, PP_ALIGN.CENTER)
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 6: What azd up Deploys
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, WHITE)
+add_text_box(slide, 0.8, 0.4, 11, 0.8, "One Command. Everything Configured.", 36, DARK_BLUE, True)
+
+add_shape_box(slide, 3.5, 1.4, 6, 0.8, DARK_BLUE, "azd up", 32, WHITE)
+
+components = [
+    ("Infrastructure (Bicep)", ["SRE Agent", "Container Apps (API + Frontend)", "ACR, Log Analytics, App Insights", "Alert rules, Managed Identity + RBAC"]),
+    ("Agent Config (REST APIs)", ["Knowledge base (2 runbooks)", "3 subagents (incident, code, triage)", "GitHub MCP connector", "Response plan, Scheduled task"]),
+]
+
+x = 1
+for title, items in components:
+    add_shape_box(slide, x, 2.6, 5.5, 0.6, AZURE_BLUE, title, 18, WHITE)
+    y = 3.4
+    for item in items:
+        add_text_box(slide, x + 0.3, y, 5, 0.4, f"✓  {item}", 16, DARK_GRAY)
+        y += 0.45
+    x += 6
+
+add_text_box(slide, 0.8, 5.8, 11, 0.6, "~8-12 minutes from clone to fully working agent", 20, ACCENT_GREEN, True, PP_ALIGN.CENTER)
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 7: GA Announcement
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, DARK_BLUE)
+add_text_box(slide, 1, 0.5, 11, 1, "Generally Available", 44, WHITE, True, PP_ALIGN.CENTER)
+add_text_box(slide, 1, 1.5, 11, 0.6, "March 10, 2026", 28, ACCENT_GREEN, True, PP_ALIGN.CENTER)
+
+features = [
+    ("Enterprise SLA", "Production-grade support"),
+    ("3 Regions", "East US 2, Sweden Central, Australia East"),
+    ("Incident Platforms", "Azure Monitor, PagerDuty, ServiceNow"),
+    ("MCP Extensibility", "Connect any API — GitHub, Datadog, Jira, yours"),
+    ("Subagents", "Specialized agents for different domains"),
+    ("Knowledge + Memory", "Your runbooks + learns from past incidents"),
+]
+
+y = 2.5
+for title, desc in features:
+    add_text_box(slide, 2, y, 4, 0.4, title, 20, WHITE, True)
+    add_text_box(slide, 6, y, 6, 0.4, desc, 18, RGBColor(0xBB, 0xDD, 0xFF))
+    y += 0.6
+
+add_text_box(slide, 1, 6.3, 11, 0.5, "sre.azure.com/docs", 18, RGBColor(0x77, 0x99, 0xBB), False, PP_ALIGN.CENTER)
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 8: Before / After
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, WHITE)
+add_text_box(slide, 0.8, 0.4, 11, 0.8, "The Transformation", 36, DARK_BLUE, True)
+
+# Before
+add_shape_box(slide, 0.8, 1.5, 5.5, 0.7, RGBColor(0xCC, 0x33, 0x33), "Before SRE Agent", 22, WHITE)
+befores = [
+    "2 hours every morning sorting tickets",
+    "Context-switch between 5+ tools",
+    "Knowledge locked in senior engineers",
+    "Same diagnostic steps, error-prone at 3am",
+]
+y = 2.5
+for b in befores:
+    add_text_box(slide, 1.2, y, 5, 0.4, f"✗  {b}", 16, RGBColor(0xCC, 0x33, 0x33))
+    y += 0.5
+
+# After
+add_shape_box(slide, 7, 1.5, 5.5, 0.7, ACCENT_GREEN, "After SRE Agent", 22, WHITE)
+afters = [
+    "Issues triaged before anyone logs in",
+    "Investigations complete with evidence",
+    "Runbooks executed consistently, 24/7",
+    "Engineers solve problems, not gather data",
+]
+y = 2.5
+for a in afters:
+    add_text_box(slide, 7.4, y, 5, 0.4, f"✓  {a}", 16, ACCENT_GREEN)
+    y += 0.5
+
+add_shape_box(slide, 2, 5.2, 9, 1, DARK_BLUE, '"The best incident response is the one you sleep through."', 22, WHITE)
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 9: Let's Try It
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, AZURE_BLUE)
+add_text_box(slide, 1, 1, 11, 1.5, "Let's Try It!", 54, WHITE, True, PP_ALIGN.CENTER)
+add_text_box(slide, 1, 3, 11, 1, "Open your lab instructions and follow along", 24, RGBColor(0xDD, 0xEE, 0xFF), False, PP_ALIGN.CENTER)
+
+links = [
+    ("Portal", "sre.azure.com"),
+    ("Documentation", "sre.azure.com/docs"),
+    ("Lab Repo", "github.com/dm-chelupati/sre-agent-lab"),
+]
+y = 4.5
+for label, url in links:
+    add_text_box(slide, 3, y, 3, 0.4, label, 20, WHITE, True, PP_ALIGN.RIGHT)
+    add_text_box(slide, 6.5, y, 5, 0.4, url, 20, RGBColor(0xDD, 0xEE, 0xFF), False, PP_ALIGN.LEFT)
+    y += 0.5
+
+# ═══════════════════════════════════════════════════════════════
+# SLIDE 10: Resources
+# ═══════════════════════════════════════════════════════════════
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+add_bg(slide, WHITE)
+add_text_box(slide, 0.8, 0.4, 11, 0.8, "Resources", 36, DARK_BLUE, True)
+
+resources = [
+    ("SRE Agent Portal", "sre.azure.com"),
+    ("Documentation", "sre.azure.com/docs"),
+    ("Lab Source Code", "github.com/dm-chelupati/sre-agent-lab"),
+    ("Blog", "aka.ms/sreagent/blog"),
+    ("Samples", "github.com/microsoft/sre-agent/tree/main/samples"),
+]
+y = 1.8
+for label, url in resources:
+    add_text_box(slide, 1.5, y, 4, 0.4, label, 20, DARK_GRAY, True)
+    add_text_box(slide, 5.5, y, 7, 0.4, url, 18, AZURE_BLUE)
+    y += 0.55
+
+add_text_box(slide, 0.8, 5, 11, 0.6, "Blog posts to read after the lab:", 18, DARK_GRAY, True)
+blogs = [
+    "Stop Running Runbooks at 3am — Let Azure SRE Agent Do Your On-Call Grunt Work",
+    "Extend SRE Agent with MCP — Build an Agentic Workflow to Triage Customer Issues",
+]
+y = 5.6
+for b in blogs:
+    add_text_box(slide, 1.2, y, 11, 0.4, f"→  {b}", 15, RGBColor(0x66, 0x66, 0x66))
+    y += 0.45
+
+# Save
+output_path = "/tmp/sre-agent-lab/docs/Azure-SRE-Agent-MVP-Lab.pptx"
+prs.save(output_path)
+print(f"✅ PowerPoint saved to: {output_path}")

--- a/samples/hands-on-lab/scripts/post-provision-srectl.sh
+++ b/samples/hands-on-lab/scripts/post-provision-srectl.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# =============================================================================
+# Post-Provision Script for SRE Agent Lab
+# Runs automatically after 'azd provision' via the postprovision hook
+#
+# Configures:
+#   - srectl initialization
+#   - Knowledge base upload (http-500-errors.md + grubify-architecture.md)
+#   - Incident handler subagent
+#   - Incident response plan
+#   - (Optional) GitHub MCP connector + additional subagents if GITHUB_PAT is set
+# =============================================================================
+set -e
+
+echo ""
+echo "============================================="
+echo "  SRE Agent Lab — Post-Provision Setup"
+echo "============================================="
+echo ""
+
+# Get outputs from azd environment
+AGENT_ENDPOINT=$(azd env get-values 2>/dev/null | grep "^SRE_AGENT_ENDPOINT=" | cut -d'=' -f2 | tr -d '"')
+AGENT_NAME=$(azd env get-values 2>/dev/null | grep "^SRE_AGENT_NAME=" | cut -d'=' -f2 | tr -d '"')
+RESOURCE_GROUP=$(azd env get-values 2>/dev/null | grep "^AZURE_RESOURCE_GROUP=" | cut -d'=' -f2 | tr -d '"')
+CONTAINER_APP_URL=$(azd env get-values 2>/dev/null | grep "^CONTAINER_APP_URL=" | cut -d'=' -f2 | tr -d '"')
+GITHUB_PAT_VALUE=$(azd env get-values 2>/dev/null | grep "^GITHUB_PAT=" | cut -d'=' -f2 | tr -d '"')
+
+# Check GITHUB_PAT from env var if not in azd env
+if [ -z "$GITHUB_PAT_VALUE" ] && [ -n "$GITHUB_PAT" ]; then
+  GITHUB_PAT_VALUE="$GITHUB_PAT"
+fi
+
+echo "Agent Endpoint: ${AGENT_ENDPOINT}"
+echo "Agent Name:     ${AGENT_NAME}"
+echo "Resource Group: ${RESOURCE_GROUP}"
+echo ""
+
+# ---- Step 1: Initialize srectl ----
+echo "Step 1/5: Initializing srectl..."
+srectl init --resource-url "${AGENT_ENDPOINT}"
+echo "  ✓ srectl initialized"
+echo ""
+
+# ---- Step 2: Upload knowledge base ----
+echo "Step 2/5: Uploading knowledge base..."
+srectl doc upload --file ./knowledge-base/http-500-errors.md
+echo "  ✓ Uploaded http-500-errors.md"
+srectl doc upload --file ./knowledge-base/grubify-architecture.md
+echo "  ✓ Uploaded grubify-architecture.md"
+echo ""
+
+# ---- Step 3: Create incident handler subagent ----
+echo "Step 3/5: Creating incident handler subagent..."
+if [ -n "$GITHUB_PAT_VALUE" ]; then
+  echo "  GitHub PAT detected — using full config (with GitHub tools)"
+  srectl agent apply -f sre-config/agents/incident-handler-full.yaml
+else
+  echo "  No GitHub PAT — using core config (log analysis only)"
+  srectl agent apply -f sre-config/agents/incident-handler-core.yaml
+fi
+echo "  ✓ incident-handler subagent created"
+echo ""
+
+# ---- Step 4: Create incident response plan ----
+echo "Step 4/5: Creating incident response plan..."
+srectl incidenthandler create \
+  --id grubify-http-errors \
+  --name "Grubify HTTP 500 Errors" \
+  --priority 3 \
+  --title-contains "500" \
+  --handling-agent incident-handler \
+  --max-attempts 3
+echo "  ✓ Incident response plan created"
+echo ""
+
+# ---- Step 5: GitHub integration (optional) ----
+if [ -n "$GITHUB_PAT_VALUE" ]; then
+  echo "Step 5/5: Configuring GitHub integration..."
+
+  # Configure GitHub MCP connector
+  CONNECTOR_FILE=$(mktemp)
+  sed "s|PLACEHOLDER_GITHUB_PAT|${GITHUB_PAT_VALUE}|g" \
+    sre-config/connectors/github-mcp.yaml > "$CONNECTOR_FILE"
+  srectl connector apply -f "$CONNECTOR_FILE"
+  rm -f "$CONNECTOR_FILE"
+  echo "  ✓ GitHub MCP connector configured"
+
+  # Upload triage runbook
+  srectl doc upload --file ./knowledge-base/github-issue-triage.md
+  echo "  ✓ Uploaded github-issue-triage.md"
+
+  # Create additional subagents
+  srectl agent apply -f sre-config/agents/code-analyzer.yaml
+  echo "  ✓ code-analyzer subagent created"
+
+  srectl agent apply -f sre-config/agents/issue-triager.yaml
+  echo "  ✓ issue-triager subagent created"
+
+  echo ""
+  echo "  GitHub integration: ✅ Configured"
+else
+  echo "Step 5/5: GitHub integration — ⏭️  Skipped (no PAT provided)"
+  echo ""
+  echo "  To add GitHub later, run:"
+  echo "    export GITHUB_PAT=<your-pat>"
+  echo "    ./scripts/setup-github.sh"
+fi
+
+echo ""
+echo "============================================="
+echo "  ✅ SRE Agent Lab Setup Complete!"
+echo "============================================="
+echo ""
+echo "  SRE Agent Portal:  https://sre.azure.com"
+echo "  Grubify App:       ${CONTAINER_APP_URL}"
+echo "  Resource Group:    ${RESOURCE_GROUP}"
+echo ""
+echo "  Next steps:"
+echo "    1. Open https://sre.azure.com and find your agent"
+echo "    2. Explore Builder > Knowledge base, Connectors, Subagents"
+echo "    3. Run ./scripts/break-app.sh to trigger an incident"
+echo "    4. Watch the agent investigate and remediate!"
+echo ""

--- a/samples/hands-on-lab/scripts/post-provision.sh
+++ b/samples/hands-on-lab/scripts/post-provision.sh
@@ -1,0 +1,511 @@
+#!/bin/bash
+# =============================================================================
+# post-provision.sh — Runs automatically after azd provision
+#
+# Configures the SRE Agent using dataplane REST APIs (no srectl dependency):
+#   - Uploads knowledge base files
+#   - Creates subagents via dataplane v2 API
+#   - Creates incident response plan
+#   - (Optional) GitHub MCP + additional subagents
+# =============================================================================
+set -uo pipefail
+
+# Windows compatibility: python3 may be 'python' on Windows
+if command -v python3 &>/dev/null; then
+  PYTHON=python3
+elif command -v python &>/dev/null; then
+  PYTHON=python
+else
+  echo "❌ ERROR: Python not found. Install Python 3."
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+# Flags
+SKIP_BUILD=""
+RETRY_MODE=""
+for arg in "$@"; do
+  case "$arg" in
+    --skip-build) SKIP_BUILD="true" ;;
+    --retry)      SKIP_BUILD="true"; RETRY_MODE="true" ;;
+  esac
+done
+
+echo ""
+echo "============================================="
+echo "  SRE Agent Lab — Post-Provision Setup"
+echo "============================================="
+echo ""
+
+# ── Read azd outputs ─────────────────────────────────────────────────────────
+AGENT_ENDPOINT=$(azd env get-value SRE_AGENT_ENDPOINT 2>/dev/null || echo "")
+AGENT_NAME=$(azd env get-value SRE_AGENT_NAME 2>/dev/null || echo "")
+RESOURCE_GROUP=$(azd env get-value AZURE_RESOURCE_GROUP 2>/dev/null || echo "")
+CONTAINER_APP_URL=$(azd env get-value CONTAINER_APP_URL 2>/dev/null || echo "")
+CONTAINER_APP_NAME=$(azd env get-value CONTAINER_APP_NAME 2>/dev/null || echo "")
+FRONTEND_APP_NAME=$(azd env get-value FRONTEND_APP_NAME 2>/dev/null || echo "")
+ACR_NAME=$(azd env get-value AZURE_CONTAINER_REGISTRY_NAME 2>/dev/null || echo "")
+GITHUB_PAT_VALUE=$(azd env get-value GITHUB_PAT 2>/dev/null || echo "")
+GITHUB_USER=$(azd env get-value GITHUB_USER 2>/dev/null || echo "")
+# azd env get-value outputs error text when key is missing — clean it up
+if echo "$GITHUB_PAT_VALUE" | grep -q "ERROR\|not found"; then
+  GITHUB_PAT_VALUE=""
+fi
+if echo "$GITHUB_USER" | grep -q "ERROR\|not found"; then
+  GITHUB_USER=""
+fi
+export GITHUB_PAT_VALUE
+# Build the repo name from username (defaults to dm-chelupati if not set)
+export GITHUB_REPO="${GITHUB_USER:+${GITHUB_USER}/grubify}"
+GITHUB_REPO="${GITHUB_REPO:-dm-chelupati/grubify}"
+export GITHUB_REPO
+
+if [ -z "$AGENT_ENDPOINT" ] || [ -z "$AGENT_NAME" ]; then
+  echo "❌ ERROR: Could not read agent details from azd environment."
+  exit 1
+fi
+
+echo "📡 Agent: ${AGENT_ENDPOINT}"
+echo "📦 RG:    ${RESOURCE_GROUP}"
+echo ""
+
+# ── Step 0: Build & deploy Grubify via ACR (cloud-side, no local Docker) ─────
+if [ -n "$SKIP_BUILD" ]; then
+  echo "🐳 Step 0/5: ⏭️  Skipped (--skip-build or --retry)"
+elif [ -n "$ACR_NAME" ] && [ -d "$PROJECT_DIR/src/grubify/GrubifyApi" ]; then
+  echo "🐳 Step 0/5: Building Grubify container images in ACR..."
+  ACR_LOGIN_SERVER=$(az acr show --name "$ACR_NAME" --query loginServer -o tsv 2>/dev/null)
+  IMAGE_TAG="${ACR_LOGIN_SERVER}/grubify-api:latest"
+
+  echo "   Building API image in ACR (this takes ~1 min)..."
+  az acr build \
+    --registry "$ACR_NAME" \
+    --image "grubify-api:latest" \
+    --file "$PROJECT_DIR/src/grubify/GrubifyApi/Dockerfile" \
+    "$PROJECT_DIR/src/grubify/GrubifyApi" \
+    --no-logs --output none 2>/dev/null
+
+  echo "   ✅ Built: ${IMAGE_TAG}"
+
+  # Update the container app to use the new image
+  echo "   Deploying API to container app..."
+  az containerapp update \
+    --name "$CONTAINER_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --image "$IMAGE_TAG" \
+    --output none 2>/dev/null
+
+  # Refresh the app URL after update
+  CONTAINER_APP_URL=$(az containerapp show --name "$CONTAINER_APP_NAME" --resource-group "$RESOURCE_GROUP" --query "properties.configuration.ingress.fqdn" -o tsv 2>/dev/null)
+  CONTAINER_APP_URL="https://${CONTAINER_APP_URL}"
+  azd env set CONTAINER_APP_URL "$CONTAINER_APP_URL" 2>/dev/null || true
+
+  echo "   ✅ API deployed: ${CONTAINER_APP_URL}"
+
+  # Build and deploy frontend
+  if [ -d "$PROJECT_DIR/src/grubify/grubify-frontend" ]; then
+    FRONTEND_IMAGE="${ACR_LOGIN_SERVER}/grubify-frontend:latest"
+
+    echo "   Building frontend image in ACR (this takes ~2-3 min)..."
+    az acr build \
+      --registry "$ACR_NAME" \
+      --image "grubify-frontend:latest" \
+      --file "$PROJECT_DIR/src/grubify/grubify-frontend/Dockerfile" \
+      "$PROJECT_DIR/src/grubify/grubify-frontend" \
+      --no-logs --output none 2>/dev/null
+
+    echo "   ✅ Frontend built"
+    echo "   Deploying frontend to container app..."
+    az containerapp update \
+      --name "$FRONTEND_APP_NAME" \
+      --resource-group "$RESOURCE_GROUP" \
+      --image "$FRONTEND_IMAGE" \
+      --set-env-vars "REACT_APP_API_BASE_URL=https://${CONTAINER_APP_URL#https://}/api" \
+      --output none 2>/dev/null
+
+    FRONTEND_URL=$(az containerapp show --name "$FRONTEND_APP_NAME" --resource-group "$RESOURCE_GROUP" --query "properties.configuration.ingress.fqdn" -o tsv 2>/dev/null)
+    FRONTEND_URL="https://${FRONTEND_URL}"
+    azd env set FRONTEND_APP_URL "$FRONTEND_URL" 2>/dev/null || true
+
+    echo "   ✅ Frontend deployed: ${FRONTEND_URL}"
+
+    # Set CORS on the API to allow requests from the frontend
+    echo "   Configuring CORS on API..."
+    az containerapp update \
+      --name "$CONTAINER_APP_NAME" \
+      --resource-group "$RESOURCE_GROUP" \
+      --set-env-vars "AllowedOrigins__0=${FRONTEND_URL}" \
+      --output none 2>/dev/null
+    echo "   ✅ CORS configured"
+  fi
+else
+  echo "   ⏭️  Skipped (ACR or source not found — using placeholder image)"
+fi
+echo ""
+
+# ── Helper: Get bearer token ─────────────────────────────────────────────────
+get_token() {
+  az account get-access-token --resource https://azuresre.dev --query accessToken -o tsv 2>/dev/null
+}
+
+# ── Helper: Create subagent via dataplane v2 API ─────────────────────────────
+create_subagent() {
+  local yaml_file="$1"
+  local agent_name="$2"
+  local token
+  token=$(get_token)
+
+  # Convert YAML spec to API JSON using helper script
+  $PYTHON "$SCRIPT_DIR/yaml-to-api-json.py" "$yaml_file" "/tmp/${agent_name}-body.json" > /dev/null 2>&1
+
+  local http_code
+  http_code=$(curl -s -o /tmp/${agent_name}-resp.txt -w "%{http_code}" \
+    -X PUT "${AGENT_ENDPOINT}/api/v2/extendedAgent/agents/${agent_name}" \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json" \
+    --data-binary @"/tmp/${agent_name}-body.json")
+
+  if [ "$http_code" = "200" ] || [ "$http_code" = "201" ] || [ "$http_code" = "202" ] || [ "$http_code" = "204" ]; then
+    echo "   ✅ Created: ${agent_name}"
+  else
+    echo "   ⚠️  ${agent_name} returned HTTP ${http_code}"
+    cat "/tmp/${agent_name}-resp.txt" 2>/dev/null | head -3
+  fi
+  rm -f "/tmp/${agent_name}-body.json" "/tmp/${agent_name}-resp.txt"
+}
+
+# ── Helper: Check if something exists (for --retry mode) ─────────────────────
+check_kb_files() {
+  local token=$(get_token)
+  local count=$(curl -s "${AGENT_ENDPOINT}/api/v1/AgentMemory/files" -H "Authorization: Bearer ${token}" 2>/dev/null | $PYTHON -c "import sys,json; print(len(json.load(sys.stdin).get('files',[])))" 2>/dev/null || echo "0")
+  [ "$count" -ge 2 ]
+}
+
+check_subagent_exists() {
+  local name="$1"
+  local token=$(get_token)
+  local code=$(curl -s -o /dev/null -w "%{http_code}" "${AGENT_ENDPOINT}/api/v2/extendedAgent/agents/${name}" -H "Authorization: Bearer ${token}" 2>/dev/null)
+  [ "$code" = "200" ]
+}
+
+check_response_plan_exists() {
+  local token=$(get_token)
+  local count=$(curl -s "${AGENT_ENDPOINT}/api/v1/incidentPlayground/filters" -H "Authorization: Bearer ${token}" 2>/dev/null | $PYTHON -c "import sys,json; d=json.load(sys.stdin); print(len([f for f in d if f.get('handlingAgent')]))" 2>/dev/null || echo "0")
+  [ "$count" -ge 1 ]
+}
+
+check_connector_exists() {
+  local count=$(az rest --method GET --url "https://management.azure.com${AGENT_RESOURCE_ID}/DataConnectors?api-version=${API_VERSION}" --query "length(value)" -o tsv 2>/dev/null || echo "0")
+  [ "$count" -ge 1 ]
+}
+
+# ── Step 1: Upload knowledge base files ──────────────────────────────────────
+echo "📚 Step 1/5: Uploading knowledge base..."
+TOKEN=$(get_token)
+
+# Build curl args array dynamically from knowledge-base/ directory
+CURL_ARGS=(-s -o /dev/null -w "%{http_code}" \
+  -X POST "${AGENT_ENDPOINT}/api/v1/AgentMemory/upload" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -F "triggerIndexing=true")
+KB_NAMES=""
+for f in ./knowledge-base/*.md; do
+  CURL_ARGS+=(-F "files=@${f};type=text/plain")
+  KB_NAMES="${KB_NAMES} $(basename "$f")"
+done
+
+HTTP_CODE=$(curl "${CURL_ARGS[@]}")
+
+if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ]; then
+  echo "   ✅ Uploaded:${KB_NAMES}"
+else
+  echo "   ⚠️  Upload returned HTTP ${HTTP_CODE}"
+fi
+echo ""
+
+# ── Step 2: Create incident-handler subagent ─────────────────────────────────
+echo "🤖 Step 2/5: Creating/updating incident-handler subagent..."
+if [ -n "$GITHUB_PAT_VALUE" ]; then
+  echo "   GitHub PAT detected — using full config"
+  create_subagent "sre-config/agents/incident-handler-full.yaml" "incident-handler"
+else
+  echo "   No GitHub PAT — using core config"
+  create_subagent "sre-config/agents/incident-handler-core.yaml" "incident-handler"
+fi
+echo ""
+
+# ── Step 3: Enable Azure Monitor + create response plan ──────────────────────
+echo "🚨 Step 3/5: Enabling Azure Monitor incident platform..."
+SUBSCRIPTION_ID=$(az account show --query id -o tsv 2>/dev/null)
+AGENT_RESOURCE_ID="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.App/agents/${AGENT_NAME}"
+API_VERSION="2025-05-01-preview"
+
+if [ -n "$RETRY_MODE" ] && check_response_plan_exists; then
+  echo "   ⏭️  Response plan already exists"
+else
+  # Enable Azure Monitor as the incident platform (ARM PATCH)
+  if az rest --method PATCH \
+    --url "https://management.azure.com${AGENT_RESOURCE_ID}?api-version=${API_VERSION}" \
+    --body '{"properties":{"incidentManagementConfiguration":{"type":"AzMonitor","connectionName":"azmonitor"}}}' \
+    --output none 2>&1; then
+    echo "   ✅ Azure Monitor enabled"
+  else
+    echo "   ⚠️  Could not enable Azure Monitor"
+  fi
+
+  # Wait for Azure Monitor platform to initialize before creating filters
+  echo "   Waiting for Azure Monitor to initialize..."
+  sleep 10
+
+  # Delete any existing filters (previous runs)
+  TOKEN=$(get_token)
+  curl -s -o /dev/null -X DELETE "${AGENT_ENDPOINT}/api/v1/incidentPlayground/filters/grubify-http-errors" \
+    -H "Authorization: Bearer ${TOKEN}" 2>/dev/null || true
+
+# Create response plan with retry (Azure Monitor needs time to be ready)
+FILTER_CREATED=false
+for attempt in 1 2 3; do
+  TOKEN=$(get_token)
+  HTTP_CODE=$(curl -s -o /tmp/response-plan-resp.txt -w "%{http_code}" \
+    -X PUT "${AGENT_ENDPOINT}/api/v1/incidentPlayground/filters/grubify-http-errors" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data-binary '{"id":"grubify-http-errors","name":"Grubify HTTP Errors","priorities":["Sev0","Sev1","Sev2","Sev3","Sev4"],"titleContains":"","handlingAgent":"incident-handler","agentMode":"autonomous","maxAttempts":3}')
+
+  if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "202" ] || [ "$HTTP_CODE" = "409" ]; then
+    echo "   ✅ Response plan → incident-handler"
+    FILTER_CREATED=true
+    break
+  else
+    echo "   ⏳ Attempt $attempt/3: HTTP ${HTTP_CODE}, retrying in 10s..."
+    sleep 10
+  fi
+done
+
+  if [ "$FILTER_CREATED" = "false" ]; then
+    echo "   ⚠️  Response plan failed after 3 attempts (set up in portal or run: ./scripts/post-provision.sh --retry)"
+  fi
+  rm -f /tmp/response-plan-resp.txt
+fi
+
+# Always delete the default quickstart handler (auto-created by Azure Monitor platform)
+TOKEN=$(get_token)
+curl -s -o /dev/null -X DELETE "${AGENT_ENDPOINT}/api/v1/incidentPlayground/filters/quickstart_handler" \
+  -H "Authorization: Bearer ${TOKEN}" 2>/dev/null || true
+
+echo ""
+
+# ── Step 4: GitHub integration (optional) ────────────────────────────────────
+echo "🔗 Step 4/5: GitHub integration..."
+
+if [ -n "$GITHUB_PAT_VALUE" ]; then
+  # Create GitHub MCP connector via ARM API (use temp file to avoid shell escaping issues)
+  echo "   Creating GitHub MCP connector..."
+  echo "   PAT length: ${#GITHUB_PAT_VALUE}"
+  $PYTHON -c "
+import json, os
+pat = os.environ.get('GITHUB_PAT_VALUE', '')
+print(f'   Python PAT length: {len(pat)}')
+body = {'properties': {'name': 'github-mcp', 'dataConnectorType': 'Mcp', 'dataSource': 'placeholder', 'extendedProperties': {'type': 'http', 'endpoint': 'https://api.githubcopilot.com/mcp/', 'authType': 'BearerToken', 'bearerToken': pat}, 'identity': 'system'}}
+with open('/tmp/mcp-connector-body.json', 'w') as f: json.dump(body, f)
+"
+  if az rest --method PUT \
+    --url "https://management.azure.com${AGENT_RESOURCE_ID}/DataConnectors/github-mcp?api-version=${API_VERSION}" \
+    --body @/tmp/mcp-connector-body.json \
+    --output none 2>&1; then
+    echo "   ✅ GitHub MCP connector created"
+  else
+    echo "   ⚠️  Could not create GitHub MCP connector (check PAT and permissions)"
+  fi
+  rm -f /tmp/mcp-connector-body.json
+
+  # Upload triage runbook
+  TOKEN=$(get_token)
+  curl -s -o /dev/null \
+    -X POST "${AGENT_ENDPOINT}/api/v1/AgentMemory/upload" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -F "triggerIndexing=true" \
+    -F "files=@./knowledge-base/github-issue-triage.md;type=text/plain"
+  echo "   ✅ Uploaded: github-issue-triage.md"
+
+  # Create sample customer issues for triage demo
+  echo "   Creating sample customer issues..."
+  export GITHUB_REPO GITHUB_PAT_VALUE
+  export GITHUB_PAT="${GITHUB_PAT_VALUE}"
+  bash ./scripts/create-sample-issues.sh "${GITHUB_REPO}" 2>/dev/null || echo "   ⚠️  Could not create sample issues"
+
+  # Create additional subagents
+  create_subagent "sre-config/agents/code-analyzer.yaml" "code-analyzer"
+  create_subagent "sre-config/agents/issue-triager.yaml" "issue-triager"
+
+  # Create scheduled task to triage issues every 12 hours
+  echo "   Creating scheduled task for issue triage..."
+  TOKEN=$(get_token)
+
+  # Delete any existing tasks with the same name to avoid duplicates
+  EXISTING_TASKS=$(curl -s "${AGENT_ENDPOINT}/api/v1/scheduledtasks" -H "Authorization: Bearer ${TOKEN}" 2>/dev/null || echo "[]")
+  echo "$EXISTING_TASKS" | $PYTHON -c "
+import sys,json
+try:
+    tasks=json.load(sys.stdin)
+    for t in tasks:
+        if t.get('name')=='triage-grubify-issues':
+            print(t.get('id',''))
+except: pass
+" 2>/dev/null | while read -r task_id; do
+    if [ -n "$task_id" ]; then
+      curl -s -o /dev/null -X DELETE "${AGENT_ENDPOINT}/api/v1/scheduledtasks/${task_id}" -H "Authorization: Bearer ${TOKEN}" 2>/dev/null
+    fi
+  done
+
+  $PYTHON -c "
+import json, os
+repo = os.environ.get('GITHUB_REPO', 'dm-chelupati/grubify')
+body = {'name':'triage-grubify-issues','description':f'Triage customer issues in {repo} every 12 hours','cronExpression':'0 */12 * * *','agentPrompt':f'Use the issue-triager subagent to list all open issues in {repo} that have [Customer Issue] in the title and have not been triaged yet. For each untriaged customer issue, classify it, add labels, and post a triage comment following the triage runbook in the knowledge base.','agent':'issue-triager'}
+with open('/tmp/scheduled-task-body.json', 'w') as f: json.dump(body, f)
+"
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "${AGENT_ENDPOINT}/api/v1/scheduledtasks" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data-binary @/tmp/scheduled-task-body.json)
+  rm -f /tmp/scheduled-task-body.json
+  if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "202" ]; then
+    echo "   ✅ Scheduled task: triage-grubify-issues (every 12h → issue-triager)"
+  else
+    echo "   ⚠️  Scheduled task returned HTTP ${HTTP_CODE}"
+  fi
+
+  echo ""
+  echo "   GitHub integration: ✅ Configured"
+else
+  echo "   ⏭️  No GITHUB_PAT — skipping"
+  echo "   To add later: GITHUB_PAT=<pat> ./scripts/setup-github.sh"
+fi
+echo ""
+
+# ── Verification: Show what was set up ────────────────────────────────────────
+echo ""
+echo "============================================="
+echo "  📋 Verifying what was provisioned..."
+echo "============================================="
+echo ""
+TOKEN=$(get_token)
+
+# KB files
+echo "  📚 Knowledge Base:"
+KB_FILES=$(curl -s "${AGENT_ENDPOINT}/api/v1/AgentMemory/files" -H "Authorization: Bearer ${TOKEN}" 2>/dev/null)
+echo "$KB_FILES" | $PYTHON -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    for f in d.get('files',[]):
+        status='✅' if f.get('isIndexed') else '⏳'
+        print(f'     {status} {f[\"name\"]}')
+    if not d.get('files'): print('     (none)')
+except: print('     (could not retrieve)')
+" 2>/dev/null
+echo ""
+
+# Subagents
+echo "  🤖 Subagents:"
+AGENTS=$(curl -s "${AGENT_ENDPOINT}/api/v2/extendedAgent/agents" -H "Authorization: Bearer ${TOKEN}" 2>/dev/null)
+echo "$AGENTS" | $PYTHON -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    for a in d.get('value',[]):
+        tools=a.get('properties',{}).get('tools',[]) or []
+        mcp=a.get('properties',{}).get('mcpTools',[]) or []
+        all_tools=tools+mcp
+        print(f'     ✅ {a[\"name\"]} ({len(all_tools)} tools)')
+    if not d.get('value'): print('     (none)')
+except: print('     (could not retrieve)')
+" 2>/dev/null
+echo ""
+
+# Connectors
+echo "  🔗 Connectors:"
+CONNECTORS=$(az rest --method GET --url "https://management.azure.com${AGENT_RESOURCE_ID}/DataConnectors?api-version=${API_VERSION}" --query "value[].{name:name,state:properties.provisioningState}" -o json 2>/dev/null || echo "[]")
+echo "$CONNECTORS" | $PYTHON -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    for c in d:
+        state='✅' if c.get('state')=='Succeeded' else '⏳ '+str(c.get('state',''))
+        print(f'     {state} {c[\"name\"]}')
+    if not d: print('     (none — GitHub PAT not provided or connector pending)')
+except: print('     (could not retrieve)')
+" 2>/dev/null
+echo ""
+
+# Response plans
+echo "  🚨 Response Plans:"
+FILTERS=$(curl -s "${AGENT_ENDPOINT}/api/v1/incidentPlayground/filters" -H "Authorization: Bearer ${TOKEN}" 2>/dev/null)
+echo "$FILTERS" | $PYTHON -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    for f in d:
+        agent=f.get('handlingAgent','(none)')
+        name=f.get('id','?')
+        print(f'     ✅ {name} → subagent: {agent}')
+    if not d: print('     (none)')
+except: print('     (could not retrieve)')
+" 2>/dev/null
+echo ""
+
+# Incident platform
+echo "  📡 Incident Platform:"
+PLATFORM_RAW=$(curl -s "${AGENT_ENDPOINT}/api/v1/incidentPlayground/incidentPlatformType" -H "Authorization: Bearer ${TOKEN}" 2>/dev/null || echo "{}")
+echo "$PLATFORM_RAW" | $PYTHON -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    ptype = d.get('incidentPlatformType', 'Unknown') if isinstance(d, dict) else str(d)
+    icon = '✅' if ptype == 'AzMonitor' else '⚠️'
+    display = {'AzMonitor': 'Azure Monitor', 'None': 'Not configured'}.get(ptype, ptype)
+    print(f'     {icon} {display}')
+except: print('     ⚠️  Could not determine')
+" 2>/dev/null
+echo ""
+
+# Scheduled tasks
+echo "  ⏰ Scheduled Tasks:"
+TASKS=$(curl -s "${AGENT_ENDPOINT}/api/v1/scheduledtasks" -H "Authorization: Bearer ${TOKEN}" 2>/dev/null || echo "[]")
+echo "$TASKS" | $PYTHON -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    for t in d:
+        name=t.get('name','?')
+        cron=t.get('cronExpression','?')
+        agent=t.get('agent','(none)')
+        status=t.get('status','?')
+        icon='✅' if status=='Active' else '⏸️'
+        print(f'     {icon} {name} ({cron}) → {agent}')
+    if not d: print('     (none)')
+except: print('     (could not retrieve)')
+" 2>/dev/null
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo "============================================="
+echo "  ✅ SRE Agent Lab Setup Complete!"
+echo "============================================="
+echo ""
+echo "  🤖 Portal:  https://sre.azure.com"
+echo "  🌐 App:     ${CONTAINER_APP_URL}"
+echo "  📦 RG:      ${RESOURCE_GROUP}"
+echo ""
+echo "  👉 Go to https://sre.azure.com and explore:"
+echo "     1. Builder → Knowledge base (see uploaded runbooks)"
+echo "     2. Builder → Subagent builder (see subagents + tools)"
+echo "     3. Builder → Connectors (see GitHub MCP)"
+echo "     4. Settings → Incident platform (Azure Monitor)"
+echo ""
+echo "  Then run: ./scripts/break-app.sh"
+echo "============================================="

--- a/samples/hands-on-lab/scripts/setup-github-srectl.sh
+++ b/samples/hands-on-lab/scripts/setup-github-srectl.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# =============================================================================
+# Setup GitHub Integration (standalone)
+# Run this if you skipped GitHub during initial azd up and want to add it later.
+#
+# Usage:
+#   export GITHUB_PAT=<your-github-pat>
+#   ./scripts/setup-github.sh
+# =============================================================================
+set -e
+
+if [ -z "$GITHUB_PAT" ]; then
+  echo "Error: GITHUB_PAT environment variable is not set."
+  echo ""
+  echo "Usage:"
+  echo "  export GITHUB_PAT=<your-github-pat>"
+  echo "  ./scripts/setup-github.sh"
+  echo ""
+  echo "Create a PAT at https://github.com/settings/tokens with 'repo' scope."
+  exit 1
+fi
+
+echo ""
+echo "============================================="
+echo "  Adding GitHub Integration to SRE Agent"
+echo "============================================="
+echo ""
+
+# Configure GitHub MCP connector
+echo "Step 1/4: Configuring GitHub MCP connector..."
+CONNECTOR_FILE=$(mktemp)
+sed "s|PLACEHOLDER_GITHUB_PAT|${GITHUB_PAT}|g" \
+  sre-config/connectors/github-mcp.yaml > "$CONNECTOR_FILE"
+srectl connector apply -f "$CONNECTOR_FILE"
+rm -f "$CONNECTOR_FILE"
+echo "  ✓ GitHub MCP connector configured"
+
+# Upload triage runbook
+echo "Step 2/4: Uploading GitHub issue triage runbook..."
+srectl doc upload --file ./knowledge-base/github-issue-triage.md
+echo "  ✓ Uploaded github-issue-triage.md"
+
+# Upgrade incident handler to full version (with GitHub tools)
+echo "Step 3/4: Upgrading incident handler with GitHub tools..."
+srectl agent apply -f sre-config/agents/incident-handler-full.yaml
+echo "  ✓ incident-handler upgraded with GitHub tools"
+
+# Create additional subagents
+echo "Step 4/4: Creating code-analyzer and issue-triager subagents..."
+srectl agent apply -f sre-config/agents/code-analyzer.yaml
+echo "  ✓ code-analyzer subagent created"
+srectl agent apply -f sre-config/agents/issue-triager.yaml
+echo "  ✓ issue-triager subagent created"
+
+echo ""
+echo "============================================="
+echo "  ✅ GitHub Integration Configured!"
+echo "============================================="
+echo ""
+echo "  You now have:"
+echo "    • GitHub MCP connector (search code, create issues)"
+echo "    • code-analyzer subagent (source code RCA)"
+echo "    • issue-triager subagent (triage & label issues)"
+echo "    • Upgraded incident-handler (now creates GitHub issues)"
+echo ""
+echo "  Next: Try the Developer and Workflow scenarios in the lab."
+echo ""

--- a/samples/hands-on-lab/scripts/setup-github.sh
+++ b/samples/hands-on-lab/scripts/setup-github.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# =============================================================================
+# setup-github.sh — Add GitHub integration to an existing SRE Agent
+# Uses REST APIs (az rest + curl) — no srectl dependency.
+# For the srectl version, see setup-github-srectl.sh
+#
+# Usage:
+#   export GITHUB_PAT=<your-github-pat>
+#   ./scripts/setup-github.sh
+# =============================================================================
+
+# Windows compatibility: python3 may be 'python' on Windows
+if command -v python3 &>/dev/null; then
+  PYTHON=python3
+elif command -v python &>/dev/null; then
+  PYTHON=python
+else
+  echo "ERROR: Python not found"; exit 1
+fi
+set -e
+
+if [ -z "$GITHUB_PAT" ]; then
+  echo "❌ GITHUB_PAT is not set."
+  echo ""
+  echo "Usage:"
+  echo "  export GITHUB_PAT=ghp_xxxxxxxxxxxx"
+  echo "  ./scripts/setup-github.sh"
+  echo ""
+  echo "PAT needs 'repo' scope (Classic) or Contents:Read + Issues:Read/Write (Fine-grained)."
+  exit 1
+fi
+
+# Read azd environment
+AGENT_ENDPOINT=$(azd env get-value SRE_AGENT_ENDPOINT 2>/dev/null || echo "")
+AGENT_NAME=$(azd env get-value SRE_AGENT_NAME 2>/dev/null || echo "")
+RESOURCE_GROUP=$(azd env get-value AZURE_RESOURCE_GROUP 2>/dev/null || echo "")
+SUBSCRIPTION_ID=$(az account show --query id -o tsv 2>/dev/null || echo "")
+
+if [ -z "$AGENT_ENDPOINT" ] || [ -z "$AGENT_NAME" ]; then
+  echo "❌ Could not read agent details. Run from azd project directory after 'azd up'."
+  exit 1
+fi
+
+AGENT_RESOURCE_ID="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.App/agents/${AGENT_NAME}"
+API_VERSION="2025-05-01-preview"
+
+get_token() {
+  az account get-access-token --resource https://azuresre.dev --query accessToken -o tsv 2>/dev/null
+}
+
+echo ""
+echo "============================================="
+echo "  🔗 Adding GitHub Integration"
+echo "============================================="
+echo ""
+
+# Step 1: Upload triage runbook
+echo "1️⃣  Uploading triage runbook..."
+TOKEN=$(get_token)
+curl -s -X POST "${AGENT_ENDPOINT}/api/v1/AgentMemory/upload" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -F "triggerIndexing=true" \
+  -F "files=@./knowledge-base/github-issue-triage.md;type=text/plain" \
+  > /dev/null 2>&1
+echo "   ✅ Uploaded github-issue-triage.md"
+
+# Step 2: Upgrade incident handler with GitHub tools
+echo "2️⃣  Upgrading incident handler..."
+SPEC_JSON=$($PYTHON -c "
+import yaml, json
+with open('sre-config/agents/incident-handler-full.yaml') as f:
+    data = yaml.safe_load(f)
+print(json.dumps(data['spec']))
+")
+SPEC_B64=$(echo -n "$SPEC_JSON" | base64)
+az rest --method PUT \
+  --url "https://management.azure.com${AGENT_RESOURCE_ID}/subagents/incident-handler?api-version=${API_VERSION}" \
+  --body "{\"properties\":{\"value\":\"${SPEC_B64}\"}}" \
+  --output none 2>/dev/null
+echo "   ✅ incident-handler upgraded with GitHub tools"
+
+# Step 3: Create code-analyzer subagent
+echo "3️⃣  Creating code-analyzer subagent..."
+SPEC_JSON=$($PYTHON -c "
+import yaml, json
+with open('sre-config/agents/code-analyzer.yaml') as f:
+    data = yaml.safe_load(f)
+print(json.dumps(data['spec']))
+")
+SPEC_B64=$(echo -n "$SPEC_JSON" | base64)
+az rest --method PUT \
+  --url "https://management.azure.com${AGENT_RESOURCE_ID}/subagents/code-analyzer?api-version=${API_VERSION}" \
+  --body "{\"properties\":{\"value\":\"${SPEC_B64}\"}}" \
+  --output none 2>/dev/null
+echo "   ✅ code-analyzer created"
+
+# Step 4: Create issue-triager subagent
+echo "4️⃣  Creating issue-triager subagent..."
+SPEC_JSON=$($PYTHON -c "
+import yaml, json
+with open('sre-config/agents/issue-triager.yaml') as f:
+    data = yaml.safe_load(f)
+print(json.dumps(data['spec']))
+")
+SPEC_B64=$(echo -n "$SPEC_JSON" | base64)
+az rest --method PUT \
+  --url "https://management.azure.com${AGENT_RESOURCE_ID}/subagents/issue-triager?api-version=${API_VERSION}" \
+  --body "{\"properties\":{\"value\":\"${SPEC_B64}\"}}" \
+  --output none 2>/dev/null
+echo "   ✅ issue-triager created"
+
+# Save PAT to azd env
+azd env set GITHUB_PAT "$GITHUB_PAT" 2>/dev/null || true
+
+echo ""
+echo "============================================="
+echo "  ✅ GitHub Integration Complete!"
+echo "============================================="
+echo ""
+echo "  New capabilities:"
+echo "  ├── incident-handler: now searches GitHub code + creates issues"
+echo "  ├── code-analyzer: deep source code root cause analysis"
+echo "  └── issue-triager: automated issue triage from runbook"
+echo ""

--- a/samples/hands-on-lab/scripts/yaml-to-api-json.py
+++ b/samples/hands-on-lab/scripts/yaml-to-api-json.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Convert YAML subagent spec to JSON for the dataplane v2 API.
+
+The API expects an envelope: { name, type, tags, owner, properties: { ... } }
+where properties contains camelCase fields matching ExtendedAgentSpecV2.
+YAML uses snake_case (system_prompt, handoff_description, etc.) but the API
+uses camelCase (instructions, handoffDescription, etc.).
+
+Usage: yaml-to-api-json.py <yaml_file> [output_file] [github_repo]
+"""
+import yaml, json, sys, os
+
+yaml_file = sys.argv[1]
+output_file = sys.argv[2] if len(sys.argv) > 2 else "/tmp/subagent-body.json"
+github_repo = sys.argv[3] if len(sys.argv) > 3 else os.environ.get("GITHUB_REPO", "dm-chelupati/grubify")
+
+with open(yaml_file) as f:
+    data = yaml.safe_load(f)
+
+spec = data["spec"]
+
+# Substitute GITHUB_REPO_PLACEHOLDER with actual repo
+instructions = spec.get("system_prompt", "").replace("GITHUB_REPO_PLACEHOLDER", github_repo)
+handoff_desc = spec.get("handoff_description", "").replace("GITHUB_REPO_PLACEHOLDER", github_repo)
+
+# Build the API envelope matching what srectl sends
+api_body = {
+    "name": spec["name"],
+    "type": "ExtendedAgent",
+    "tags": [],
+    "owner": "",
+    "properties": {
+        "instructions": instructions,
+        "handoffDescription": handoff_desc,
+        "handoffs": spec.get("handoffs", []),
+        "tools": spec.get("tools", []),
+        "mcpTools": spec.get("mcp_tools", []),
+        "allowParallelToolCalls": True,
+        "enableSkills": True,
+    }
+}
+
+with open(output_file, "w") as f:
+    json.dump(api_body, f)
+
+print(f"Wrote {output_file} ({len(json.dumps(api_body))} bytes)")

--- a/samples/hands-on-lab/sre-config/agents/code-analyzer.yaml
+++ b/samples/hands-on-lab/sre-config/agents/code-analyzer.yaml
@@ -1,0 +1,39 @@
+api_version: azuresre.ai/v1
+kind: AgentConfiguration
+spec:
+  name: code-analyzer
+  system_prompt: |
+    You are an expert in diagnosing, finding root cause, and mitigating issues
+    in applications. When triggered:
+
+    1. Search the knowledge base for the relevant runbook (e.g., http-500-errors)
+       and execute ALL diagnostic steps — query logs, check metrics, collect evidence.
+    2. Use source code from GITHUB_REPO_PLACEHOLDER to correlate log errors to
+       specific code paths. Provide file:line references to the root cause.
+    3. Combine both log/metric evidence AND source code analysis into a full
+       root cause analysis.
+
+    Create a GitHub issue in GITHUB_REPO_PLACEHOLDER with detailed findings
+    including log evidence, metrics, code snippets, suggested fixes, and
+    remediation actions.
+
+    Always search memory for similar past incidents first.
+    Use ExecutePythonCode to plot metrics charts when presenting evidence.
+    Search memory for "incident report template" and follow that format exactly
+    when creating GitHub issues — include structured sections for Summary,
+    Impact, Timeline, Evidence, Root Cause, Remediation, and Action Items.
+    IMPORTANT: Fill out EVERY section completely — do not leave any section
+    empty or skip the References section. Include full ARM resource IDs,
+    workspace IDs, and App Insights resource IDs in References.
+  handoff_description: Deep root cause analysis using runbooks + source code, creates detailed GitHub issues
+  agent_type: Autonomous
+  tools:
+    - SearchMemory
+    - RunAzCliReadCommands
+    - RunAzCliWriteCommands
+    - GetAzCliHelp
+    - QueryLogAnalyticsByWorkspaceId
+    - QueryAppInsightsByResourceId
+    - ExecutePythonCode
+  mcp_tools:
+    - github-mcp/*

--- a/samples/hands-on-lab/sre-config/agents/incident-handler-core.yaml
+++ b/samples/hands-on-lab/sre-config/agents/incident-handler-core.yaml
@@ -1,0 +1,21 @@
+api_version: azuresre.ai/v1
+kind: AgentConfiguration
+spec:
+  name: incident-handler
+  system_prompt: |
+    You are an expert in triaging and diagnosing incidents. When triggered,
+    search the knowledge base for the relevant runbook, execute the diagnostic
+    steps, collect evidence, and provide a summary with your findings.
+
+    Always search memory for similar past incidents first.
+    Use ExecutePythonCode to plot metrics charts when presenting evidence.
+  handoff_description: Investigates incidents using runbooks and provides findings
+  agent_type: Autonomous
+  tools:
+    - SearchMemory
+    - RunAzCliReadCommands
+    - RunAzCliWriteCommands
+    - GetAzCliHelp
+    - QueryLogAnalyticsByWorkspaceId
+    - QueryAppInsightsByResourceId
+    - ExecutePythonCode

--- a/samples/hands-on-lab/sre-config/agents/incident-handler-full.yaml
+++ b/samples/hands-on-lab/sre-config/agents/incident-handler-full.yaml
@@ -1,0 +1,30 @@
+api_version: azuresre.ai/v1
+kind: AgentConfiguration
+spec:
+  name: incident-handler
+  system_prompt: |
+    You are an expert in triaging and diagnosing incidents. When triggered,
+    search the knowledge base for the relevant runbook, execute the diagnostic
+    steps, collect evidence, and create a GitHub issue in GITHUB_REPO_PLACEHOLDER
+    with your findings including root cause, evidence, and remediation actions.
+
+    Always search memory for similar past incidents first.
+    Use ExecutePythonCode to plot metrics charts when presenting evidence.
+    Search memory for "incident report template" and follow that format exactly
+    when creating GitHub issues — include structured sections for Summary,
+    Impact, Timeline, Evidence, Root Cause, Remediation, and Action Items.
+    IMPORTANT: Fill out EVERY section completely — do not leave any section
+    empty or skip the References section. Include full ARM resource IDs,
+    workspace IDs, and App Insights resource IDs in References.
+  handoff_description: Investigates incidents using runbooks and creates GitHub issues with findings
+  agent_type: Autonomous
+  tools:
+    - SearchMemory
+    - RunAzCliReadCommands
+    - RunAzCliWriteCommands
+    - GetAzCliHelp
+    - QueryLogAnalyticsByWorkspaceId
+    - QueryAppInsightsByResourceId
+    - ExecutePythonCode
+  mcp_tools:
+    - github-mcp/*

--- a/samples/hands-on-lab/sre-config/agents/issue-triager.yaml
+++ b/samples/hands-on-lab/sre-config/agents/issue-triager.yaml
@@ -1,0 +1,37 @@
+# Issue Triager Subagent (requires GitHub)
+# Scenario 3: Triage issues in dm-chelupati/grubify — label and comment
+# Pattern from: https://techcommunity.microsoft.com/blog/appsonazureblog/extend-sre-agent-with-mcp-build-an-agentic-workflow-to-triage-customer-issues/4480710
+api_version: azuresre.ai/v1
+kind: AgentConfiguration
+spec:
+  name: issue-triager
+  system_prompt: |
+    You are an expert in triaging GitHub issues. You work with the
+    GITHUB_REPO_PLACEHOLDER repository.
+
+    Use the knowledge base to search for the GitHub Issue Triage Runbook
+    that helps you classify and triage issues.
+
+    Perform all actions autonomously without waiting for user input.
+
+    For each issue in GITHUB_REPO_PLACEHOLDER that has [Customer Issue] in the
+    title and has not been triaged:
+    1. Read the issue title and description
+    2. Classify it as: Bug, Performance, Feature Request, or Question
+    3. For Bugs, pick a sub-category: api-bug, frontend-bug, infrastructure, memory-leak
+    4. Add appropriate labels based on classification and severity
+    5. Post a comment starting with "🤖 **Grubify SRE Agent Bot**" with:
+       - Your classification and sub-category
+       - Brief analysis of the issue
+       - Next steps or questions for the reporter
+       - Status indicator at the end
+    6. If it's a bug and missing required info, add "needs-more-info" label
+
+    Skip issues that do NOT have [Customer Issue] in the title.
+    Skip issues that already have a Grubify SRE Agent Bot comment.
+  handoff_description: Triages Grubify app issues by classifying, labeling, and commenting
+  agent_type: Autonomous
+  tools:
+    - SearchMemory
+  mcp_tools:
+    - github-mcp/*

--- a/samples/hands-on-lab/sre-config/connectors/github-mcp.yaml
+++ b/samples/hands-on-lab/sre-config/connectors/github-mcp.yaml
@@ -1,0 +1,11 @@
+# GitHub MCP Connector
+# The PLACEHOLDER_GITHUB_PAT token is replaced by the post-provision script
+api_version: azuresre.ai/v1
+kind: DataConnector
+spec:
+  name: github-mcp
+  type: Mcp
+  endpoint: https://api.githubcopilot.com/mcp/
+  auth:
+    type: BearerToken
+    token: PLACEHOLDER_GITHUB_PAT


### PR DESCRIPTION
Adds a complete hands-on lab under samples/hands-on-lab/ that deploys an Azure SRE Agent connected to a sample Grubify app with a single 'azd up' command. Covers 3 personas:

- IT Operations: Autonomous incident detection, KB-driven investigation
- Developer: Source code root cause analysis with GitHub MCP
- Workflow Automation: Automated issue triage via scheduled tasks

Includes:
- Bicep infra (SRE Agent, Container Apps, monitoring, alerts, RBAC)
- Post-provision script (KB upload, subagents, response plans, MCP)
- Knowledge base runbooks and incident report template
- Skillable lab instructions (8 pages with @lab tokens)
- Break-app fault injection and sample customer issues
- Windows + macOS compatible (.gitattributes, python detection)