### PR TITLE
fix: skip GitHub integration without GITHUB_USER, block dm-chelupati repo, fix clone instructions

### DIFF
--- a/labs/starter-lab/README.md
+++ b/labs/starter-lab/README.md
@@ -60,8 +60,8 @@ bash scripts/prereqs.sh
 ### macOS / Linux
 
 ```bash
-# 1. Clone the repo (labs/starter-lab branch)
-git clone https://github.com/microsoft/sre-agent.git --branch labs/starter-lab
+# 1. Clone the repo
+git clone https://github.com/microsoft/sre-agent.git
 cd sre-agent/labs/starter-lab
 
 # 2. Sign in to Azure
@@ -84,8 +84,8 @@ bash scripts/post-provision.sh
 ### Windows
 
 ```cmd
-REM 1. Clone the repo (labs/starter-lab branch)
-git clone https://github.com/microsoft/sre-agent.git --branch labs/starter-lab
+REM 1. Clone the repo
+git clone https://github.com/microsoft/sre-agent.git
 cd sre-agent\labs\starter-lab
 
 REM 2. Sign in to Azure

--- a/labs/starter-lab/lab/skillable-instructions.md
+++ b/labs/starter-lab/lab/skillable-instructions.md
@@ -156,8 +156,8 @@ In this section you will clone the lab repository and deploy all Azure resources
 1. [] Clone the lab repo and navigate into it:
 
     ```
-    git clone https://github.com/microsoft/sre-agent.git --branch labs/starter-lab
-    cd sre-agent/labs/starter-lab
+    git clone https://github.com/microsoft/sre-agent.git
+    cd sre-agent\labs\starter-lab
     ```
 
 ---
@@ -724,6 +724,6 @@ All of this was set up with a single `azd up` command.
 - [Azure SRE Agent Documentation](https://sre.azure.com/docs)
 - [Azure SRE Agent Portal](https://sre.azure.com)
 - [Grubify Sample App](https://github.com/dm-chelupati/grubify)
-- [Lab Source Code](https://github.com/microsoft/sre-agent/tree/labs/starter-lab/labs/starter-lab)
+- [Lab Source Code](https://github.com/microsoft/sre-agent/tree/main/labs/starter-lab)
 
 **Thank you for completing this lab, @lab.User.FirstName!**

--- a/labs/starter-lab/scripts/post-provision.sh
+++ b/labs/starter-lab/scripts/post-provision.sh
@@ -91,10 +91,18 @@ GITHUB_USER=$(azd env get-value GITHUB_USER 2>/dev/null || echo "")
 if echo "$GITHUB_USER" | grep -q "ERROR\|not found"; then
   GITHUB_USER=""
 fi
-# Build the repo name from username (defaults to dm-chelupati if not set)
-export GITHUB_REPO="${GITHUB_USER:+${GITHUB_USER}/grubify}"
-GITHUB_REPO="${GITHUB_REPO:-dm-chelupati/grubify}"
-export GITHUB_REPO
+# Block using dm-chelupati repo — users must set their own GITHUB_USER
+if [ "$GITHUB_USER" = "dm-chelupati" ]; then
+  echo "⚠️  GITHUB_USER is set to dm-chelupati — please use your own GitHub account."
+  echo "   Run: azd env set GITHUB_USER <your-github-username>"
+  GITHUB_USER=""
+fi
+# Build the repo name from username
+if [ -n "$GITHUB_USER" ]; then
+  export GITHUB_REPO="${GITHUB_USER}/grubify"
+else
+  export GITHUB_REPO=""
+fi
 
 if [ -z "$AGENT_ENDPOINT" ] || [ -z "$AGENT_NAME" ]; then
   echo "❌ ERROR: Could not read agent details from azd environment."
@@ -386,6 +394,7 @@ curl -s -o /dev/null -X DELETE "${AGENT_ENDPOINT}/api/v1/incidentPlayground/filt
 echo ""
 
 # ── Step 4: GitHub integration ───────────────────────────────────────────────
+if [ -n "$GITHUB_REPO" ]; then
 echo "🔗 Step 4/5: GitHub integration..."
 
 # Create GitHub OAuth connector via data plane API (no PAT needed)
@@ -496,6 +505,15 @@ curl -s -o /dev/null -w "" \
   -d "{\"name\":\"${REPO_NAME}\",\"type\":\"CodeRepo\",\"properties\":{\"url\":\"https://github.com/${GITHUB_REPO}\",\"authConnectorName\":\"github\"}}"
 echo "   ✅ Code repo: ${GITHUB_REPO}"
 echo ""
+
+else
+  echo "🔗 Step 4/5: GitHub integration... ⏭️  Skipped"
+  echo "   No GITHUB_USER set. To enable GitHub integration:"
+  echo "   1. Fork https://github.com/dm-chelupati/grubify"
+  echo "   2. Run: azd env set GITHUB_USER <your-github-username>"
+  echo "   3. Re-run: bash scripts/post-provision.sh --retry"
+  echo ""
+fi
 
 # ── Verification: Show what was set up ────────────────────────────────────────
 echo ""


### PR DESCRIPTION
- Skip GitHub connector, subagents, scheduled task, and repo if GITHUB_USER is not set
- Block GITHUB_USER=dm-chelupati to prevent users from triaging on maintainer's repo
- Fix clone instructions: remove --branch labs/starter-lab (use main)
- Show clear skip message with instructions to enable later