### PR TITLE
Update image path for architecture diagram in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Deploy an Azure SRE Agent connected to a sample application with a single `azd u
 ## Architecture
 
 <p align="center">
-  <img src="docs/architecture.svg" alt="Lab Architecture" width="960"/>
+  <img src="labs/starter-lab/docs/architecture.svg" alt="Lab Architecture" width="960"/>
 </p>
 
 ## Prerequisites


### PR DESCRIPTION
This pull request updates the documentation to point to the correct location of the architecture diagram image.

Documentation update:

* Updated the image path in the `README.md` file so that the architecture diagram now references `labs/starter-lab/docs/architecture.svg` instead of `docs/architecture.svg`.