### PR TITLE
fix: restore repo README, move lab content to labs/starter-lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,276 +1,77 @@
-# Azure SRE Agent Hands-On Lab
+# 🚀 Welcome to the Azure SRE Agent GitHub Repository!
+We’re excited to launch this space for collaboration around the [SRE Agent](https://learn.microsoft.com/en-us/azure/sre-agent/overview), a key tool in our mission to improve service reliability and operational excellence. 
 
-Deploy an Azure SRE Agent connected to a sample application with a single `azd up` command. Watch it diagnose and remediate issues autonomously.
+## This repository is a community-driven hub where you can:
+* 🐛 Report bugs encountered while using the SRE Agent 
+* 💡 Request features that would improve usability or functionality
+* ❓ Share challenges or feedback related to using the product 
+* 🤝 Engage with the team and community to help shape the future of the SRE Agent 
 
-**Learn more:** [What is Azure SRE Agent?](https://sre.azure.com/docs/overview)
+> [!NOTE]
+> This repo is not intended for integration-related issues. For those, please use the appropriate internal or partner support channels. 
 
-## Architecture
+## 🧼 Hygiene Guidelines for Creating Issues
 
-<p align="center">
-  <img src="docs/architecture.svg" alt="Lab Architecture" width="960"/>
-</p>
+To help us keep things organized and productive, please follow these simple rules:
+* Be descriptive: Include steps to reproduce, logs, screenshots, and thread ID where applicable.  
+* Use labels: Tag your issue appropriately (bug, feature-request, usability, etc.) to help with triage. 
+* Avoid duplicates: Search existing issues before creating a new one. 
+* Stay constructive: We welcome feedback, but please keep it respectful and focused. 
+* No personal data: Please do not include any personally identifiable information (PII) in your issue. 
 
-## Prerequisites
+## 🧭 How to Find the Thread ID in SRE Agent
 
-### Required Tools
+Your direct chat interaction or incident is tracked as a thread in SRE Agent. Including the Thread ID in your GitHub issue helps us investigate quickly and accurately. A thread ID is a hex string like `50f7521d-dfee-487e-9188-5abdc8adde91`.
 
-| Tool | macOS | Windows |
-|------|-------|---------|
-| [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) 2.60+ | `brew install azure-cli` | `winget install Microsoft.AzureCLI` |
-| [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) 1.9+ | `brew install azd` | `winget install Microsoft.Azd` |
-| [Git](https://git-scm.com/) 2.x | `brew install git` | `winget install Git.Git` (includes Git Bash) |
-| [Python](https://python.org) 3.10+ | `brew install python3` | `winget install Python.Python.3.12` |
+### 🔍 How to Locate the Thread ID:
+**Get thread ID for threads under "Activities" view <br />**
+<img width="722" height="126" alt="Screenshot 2025-10-09 at 3 22 07 PM" src="https://github.com/user-attachments/assets/62f6ea4b-3494-4f67-a85e-d16611f35da7" /> <br />
 
-> **Windows note:** After installing Python, disable the Windows Store app aliases:
-> **Settings → Apps → Advanced app settings → App execution aliases** → turn OFF `python.exe` and `python3.exe`
 
-### Azure Requirements
 
-- Active Azure subscription
-- **Owner** role on the subscription (needed for RBAC role assignments)
-- Register the resource provider:
-  ```bash
-  az provider register -n Microsoft.App --wait
-  ```
+**Get thread ID for threads under Incident Management view <br />** 
+step 1: <br />
+<img width="670" height="108" alt="Screenshot 2025-10-09 at 3 21 51 PM" src="https://github.com/user-attachments/assets/18794670-499b-4c74-aedd-0541621d78e6" /> <br />
 
-### Optional
 
-- GitHub account (for code search and issue triage scenarios — uses OAuth sign-in, no PAT needed)
 
-## Quick Start
 
-### Check prerequisites
+step2: <br />
+<img width="747" height="108" alt="Screenshot 2025-10-09 at 3 21 37 PM" src="https://github.com/user-attachments/assets/09dbaf67-49f5-4346-b5eb-6624f4c5b803" /> <br />
 
-Run the prereqs script to verify everything is installed:
 
-```bash
-# macOS/Linux
-bash scripts/prereqs.sh
 
-# Windows (Git Bash or CMD)
-"C:\Program Files\Git\bin\bash.exe" scripts/prereqs.sh
-```
 
-### macOS / Linux
 
-```bash
-# 1. Clone the repo
-git clone https://github.com/dm-chelupati/sre-agent-lab.git
-cd sre-agent-lab
-git submodule update --init --recursive
+## 📝 Issue Template
+When creating a new issue, please use the following format: 
 
-# 2. Sign in to Azure
-az login
-azd auth login
+**Issue Description** 
+Briefly describe the problem or request. 
 
-# 3. Create environment and deploy
-azd env new sre-lab
-azd up
-# Select your subscription and eastus2 as the region
-```
+**Agent Name** 
+name of Agent
 
-### Windows
+**Subscription ID**
+subscription in which agent is deployed 
 
-```cmd
-REM 1. Clone the repo (in CMD or PowerShell)
-git clone https://github.com/dm-chelupati/sre-agent-lab.git
-cd sre-agent-lab
-git submodule update --init --recursive
+**Region**
+Region where agent is deployed 
 
-REM 2. Sign in to Azure
-az login
-azd auth login
+**Resource group** 
+For Agent deployment related issues, provide the resource group in which it was created
 
-REM 3. Create environment and deploy
-azd env new sre-lab
-azd up
+**Thread ID** 
+Paste the thread ID from the SRE Agent portal (e.g., 50f7521d-dfee-487e-9188-5abdc8adde91) 
 
-REM If post-provision fails with 'bash not found' or 'Python not found':
-set PATH=%PATH%;C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python312
-"C:\Program Files\Git\bin\bash.exe" scripts/post-provision.sh
-```
+**Steps to Reproduce** 
+1. Describe the action you took 
+2. Mention the resource or Azure service (if involved)
+3. Describe what you expected vs. what happened
+4. include  error messages experienced by you in Incident or chat threads or ARM deployment error details or HTTP status codes
 
-Deployment takes ~8-12 minutes.
+**Expected Behavior** 
+What should happen? 
 
-## What Gets Deployed
-
-### Azure Infrastructure (via Bicep)
-
-| Resource | Service | Purpose | Docs |
-|----------|---------|---------|------|
-| SRE Agent | `Microsoft.App/agents` | AI agent for incident investigation | [Overview](https://sre.azure.com/docs/overview) |
-| Grubify API | Azure Container Apps | Sample app to monitor | |
-| Grubify Frontend | Azure Container Apps | Sample app UI | |
-| Log Analytics | `Microsoft.OperationalInsights` | Log storage for KQL queries | [Azure Observability](https://sre.azure.com/docs/capabilities/diagnose-azure-observability) |
-| App Insights | `Microsoft.Insights` | Request tracing and exceptions | |
-| Alert Rules | `Microsoft.Insights/metricAlerts` | HTTP 5xx and error log alerts | |
-| Managed Identity | `Microsoft.ManagedIdentity` | Agent identity for Azure access | [Permissions](https://sre.azure.com/docs/tutorials/agent-config/manage-permissions) |
-| Container Registry | `Microsoft.ContainerRegistry` | Grubify container images | |
-
-### RBAC Roles Assigned
-
-| Role | Scope | Purpose |
-|------|-------|---------|
-| SRE Agent Administrator | Agent resource | User can manage agent via data plane APIs | 
-| Reader | Resource group | Agent can read all resources |
-| Monitoring Reader | Resource group | Agent can read metrics and alerts |
-| Log Analytics Reader | Log Analytics workspace | Agent can query logs via KQL |
-
-See: [Manage Permissions](https://sre.azure.com/docs/tutorials/agent-config/manage-permissions)
-
-### SRE Agent Configuration (via post-provision script)
-
-| Component | Purpose | Docs |
-|-----------|---------|------|
-| Knowledge Base | HTTP error runbook, app architecture, incident template | [Memory & Knowledge](https://sre.azure.com/docs/concepts/memory) |
-| incident-handler subagent | Investigates alerts using logs, metrics, runbooks | [Custom Agents](https://sre.azure.com/docs/concepts/subagents) |
-| Response Plan | Routes HTTP 500 alerts to incident-handler | [Response Plans](https://sre.azure.com/docs/capabilities/incident-response-plans) |
-| Azure Monitor | Incident platform — alerts flow to the agent | [Incident Platforms](https://sre.azure.com/docs/concepts/incident-platforms) |
-| GitHub OAuth connector | Code search and issue management (optional) | [Connectors](https://sre.azure.com/docs/concepts/connectors) |
-| code-analyzer subagent | Source code root cause analysis | [Custom Agents](https://sre.azure.com/docs/concepts/subagents) |
-| issue-triager subagent | Automated issue triage from runbook | [Custom Agents](https://sre.azure.com/docs/concepts/subagents) |
-
-> **Note on GitHub tools:** GitHub OAuth tools (code search, issue management) are **built-in native tools**, not MCP tools. Once the GitHub OAuth connector is set up, all agents — including subagents — get access to GitHub tools automatically through global settings. No explicit `mcp_tools` assignment is needed in subagent YAML. This is different from MCP connector tools (Datadog, Splunk, etc.) which require explicit `mcp_tools` assignment.
-| Scheduled Task | Triage customer issues every 12 hours | [Scheduled Tasks](https://sre.azure.com/docs/capabilities/scheduled-tasks) |
-| Code Repo | Agent indexes the Grubify source code | [Deep Context](https://sre.azure.com/docs/concepts/workspace-tools) |
-
-## Post-Deployment
-
-### Re-run the setup script
-
-```bash
-# Full re-run (rebuilds container images + re-uploads everything)
-./scripts/post-provision.sh
-
-# Skip container image builds (just update KB, subagents, response plan)
-./scripts/post-provision.sh --retry
-
-# Windows: run from CMD with Python in PATH
-set PATH=%PATH%;C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python312
-"C:\Program Files\Git\bin\bash.exe" scripts/post-provision.sh --retry
-```
-
-### Manual container deploy (Windows fallback)
-
-If the script deploys images but the app still shows the default page:
-
-```cmd
-for /f "tokens=*" %a in ('azd env get-value AZURE_CONTAINER_REGISTRY_NAME') do set ACR=%a
-for /f "tokens=*" %a in ('azd env get-value CONTAINER_APP_NAME') do set APP=%a
-for /f "tokens=*" %a in ('azd env get-value FRONTEND_APP_NAME') do set FE=%a
-az containerapp update --name %APP% --resource-group rg-sre-lab --image %ACR%.azurecr.io/grubify-api:latest
-az containerapp update --name %FE% --resource-group rg-sre-lab --image %ACR%.azurecr.io/grubify-frontend:latest
-```
-
-## Verify Setup
-
-After deployment completes, open your agent at [sre.azure.com](https://sre.azure.com) and click **Full setup**. You should see green checkmarks on:
-
-| Card | Expected Status |
-|------|----------------|
-| **Code** | ✅ 1 repository |
-| **Incidents** | ✅ Connected to Azure Monitor |
-| **Azure resources** | ✅ 1 resource group added |
-| **Knowledge files** | ✅ 1 file |
-
-> **Checkpoint:** If any card is missing a checkmark, re-run the post-provision script: `bash scripts/post-provision.sh --retry`
-
-Once verified, click **"Done and go to agent"** to open the agent chat and start the team onboarding conversation.
-
-### Team Onboarding
-
-The agent opens a **"Team onboarding"** thread automatically. It will:
-
-1. **Explore your connected context** — reads the code repository, Azure resources, and knowledge files you connected during setup
-2. **Interview you about your team** — ask about your team structure, on-call rotation, services you own, and escalation paths
-
-Since the agent already has context from setup, try asking it questions:
-
-> *"What do you know about the Grubify app architecture?"*
->
-> *"Summarize the HTTP errors runbook"*
->
-> *"What Azure resources are in my resource group?"*
-
-The agent saves your team information to persistent memory and references it in every future investigation.
-
-> **Tip:** Ask *"What should I do next?"* for personalized recommendations based on what's connected.
-
-## Lab Scenarios
-
-### Scenario 1: IT Operations (No GitHub required)
-
-Break the app and watch the agent investigate:
-
-```bash
-./scripts/break-app.sh     # macOS/Linux
-# Windows: "C:\Program Files\Git\bin\bash.exe" scripts/break-app.sh
-```
-
-Then open [sre.azure.com](https://sre.azure.com) → Incidents to watch the agent:
-1. Detect the Azure Monitor alert
-2. Query Log Analytics for error patterns
-3. Reference the HTTP errors runbook
-4. Apply remediation (restart/scale)
-5. Summarize with root cause and evidence
-
-### Scenario 2: Developer (Requires GitHub)
-
-Ask the agent to search source code for root causes:
-- File:line references to problematic code
-- Correlation of production errors to code changes
-- Suggested fixes with before/after examples
-
-### Scenario 3: Workflow Automation (Requires GitHub)
-
-Create sample support issues and let the agent triage them:
-
-```bash
-./scripts/create-sample-issues.sh <owner/repo>
-```
-
-The agent classifies issues (Documentation, Bug, Feature Request), applies labels, and posts triage comments following the runbook.
-
-## Adding GitHub Later
-
-After initial setup, add GitHub by signing in via the OAuth URL:
-
-```bash
-./scripts/setup-github.sh   # macOS/Linux
-# Windows: "C:\Program Files\Git\bin\bash.exe" scripts/setup-github.sh
-```
-
-## Cleanup
-
-```bash
-azd down --purge
-```
-
-## Troubleshooting
-
-| Issue | Fix |
-|-------|-----|
-| `'bash' is not recognized` (Windows) | Run via: `"C:\Program Files\Git\bin\bash.exe" scripts/post-provision.sh` |
-| `Python was not found` (Windows) | Install: `winget install Python.Python.3.12`, disable App execution aliases |
-| `curl: error encountered when reading a file` | Python isn't in Git Bash PATH: `export PATH="$PATH:/c/Users/$USER/AppData/Local/Programs/Python/Python312"` |
-| `roleAssignments/write` denied | Need Owner role on subscription. Check: `az role assignment list --assignee $(az ad signed-in-user show --query id -o tsv)` |
-| `Microsoft.App not registered` | Run: `az provider register -n Microsoft.App --wait` |
-| Grubify shows default page after deploy | Run manual deploy commands (see Post-Deployment section above) |
-| Post-provision 405 on response plan | Wait 30s and run: `./scripts/post-provision.sh --retry` |
-
-## Regions
-
-SRE Agent is available in: `eastus2`, `swedencentral`, `australiaeast`
-
-## Links
-
-- [Azure SRE Agent Documentation](https://sre.azure.com/docs)
-- [Getting Started Guide](https://sre.azure.com/docs/get-started/create-and-setup)
-- [Connectors](https://sre.azure.com/docs/concepts/connectors)
-- [Custom Agents](https://sre.azure.com/docs/concepts/subagents)
-- [Incident Response](https://sre.azure.com/docs/capabilities/incident-response)
-- [Azure Observability](https://sre.azure.com/docs/capabilities/diagnose-azure-observability)
-
-## License
-
-MIT
+**Actual Behavior** 
+What actually happened 

--- a/labs/starter-lab/README.md
+++ b/labs/starter-lab/README.md
@@ -1,6 +1,8 @@
-# Azure SRE Agent — Starter Lab
+# Azure SRE Agent Hands-On Lab
 
-Deploy an Azure SRE Agent, break a sample app, and watch it diagnose and fix the issue. **~40 minutes.**
+Deploy an Azure SRE Agent connected to a sample application with a single `azd up` command. Watch it diagnose and remediate issues autonomously.
+
+**Learn more:** [What is Azure SRE Agent?](https://sre.azure.com/docs/overview)
 
 ## Architecture
 
@@ -8,200 +10,235 @@ Deploy an Azure SRE Agent, break a sample app, and watch it diagnose and fix the
   <img src="docs/architecture.svg" alt="Lab Architecture" width="960"/>
 </p>
 
-## What Gets Deployed
-
-| Resource | Purpose |
-|----------|---------|
-| **SRE Agent** | AI agent with managed identity, knowledge base, custom agents |
-| **Grubify App** | Sample food ordering app (API + Frontend on Container Apps) |
-| **Log Analytics + App Insights** | Monitoring and log storage |
-| **Azure Monitor Alert** | HTTP 5xx alert → auto-triggers agent investigation |
-| **Container Registry** | Grubify container images |
-| **Managed Identity** | Reader + Monitoring Reader + Log Analytics Reader RBAC |
-
-### SRE Agent Configuration
-
-| Component | Purpose |
-|-----------|---------|
-| **Knowledge Base** | HTTP error runbook, app architecture docs |
-| **incident-handler** | Investigates using logs, KQL, runbooks |
-| **code-analyzer** | Same + source code search, creates GitHub issues |
-| **issue-triager** | Triages customer issues with labels and comments |
-| **Response Plan** | Routes alerts to custom agents autonomously |
-| **GitHub OAuth** | Code search + issue management (optional) |
-| **Scheduled Task** | Triage issues every 12 hours (optional) |
-| **Global Tools** | DevOps + Python plotting enabled |
-
-## Lab Scenarios
-
-| # | Scenario | Persona | GitHub Required? |
-|---|----------|---------|:---:|
-| 1 | **Break app → Agent investigates logs + remediates** | IT Operations | No |
-| 2 | **Same break → Agent finds root cause in source code + creates GitHub issue** | Developer + IT | Yes |
-| 3 | **Triage customer issues → classify, label, comment** | Workflow Automation | Yes |
-
 ## Prerequisites
+
+### Required Tools
 
 | Tool | macOS | Windows |
 |------|-------|---------|
 | [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) 2.60+ | `brew install azure-cli` | `winget install Microsoft.AzureCLI` |
 | [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) 1.9+ | `brew install azd` | `winget install Microsoft.Azd` |
-| [Git](https://git-scm.com/) 2.x | `brew install git` | `winget install Git.Git` |
+| [Git](https://git-scm.com/) 2.x | `brew install git` | `winget install Git.Git` (includes Git Bash) |
 | [Python](https://python.org) 3.10+ | `brew install python3` | `winget install Python.Python.3.12` |
 
-> **Windows:** After installing Python, disable Store aliases: **Settings → Apps → App execution aliases** → turn OFF `python.exe` and `python3.exe`
+> **Windows note:** After installing Python, disable the Windows Store app aliases:
+> **Settings → Apps → Advanced app settings → App execution aliases** → turn OFF `python.exe` and `python3.exe`
 
 ### Azure Requirements
 
-- Active Azure subscription with **Owner** role
-- Register: `az provider register -n Microsoft.App --wait`
+- Active Azure subscription
+- **Owner** role on the subscription (needed for RBAC role assignments)
+- Register the resource provider:
+  ```bash
+  az provider register -n Microsoft.App --wait
+  ```
 
 ### Optional
 
-- [GitHub account](https://github.com) — fork [dm-chelupati/grubify](https://github.com/dm-chelupati/grubify/fork) for Scenarios 2 & 3
+- GitHub account (for code search and issue triage scenarios — uses OAuth sign-in, no PAT needed)
 
 ## Quick Start
 
-### One-Command Setup (Recommended)
+### Check prerequisites
 
-The `setup.sh` script handles everything: login, deploy, and configure.
-
-**macOS / Linux:**
-```bash
-git clone https://github.com/microsoft/sre-agent.git
-cd sre-agent/labs/starter-lab
-bash scripts/setup.sh
-```
-
-**Windows:**
-```cmd
-git clone https://github.com/microsoft/sre-agent.git
-cd sre-agent\labs\starter-lab
-"C:\Program Files\Git\bin\bash.exe" scripts/setup.sh
-```
-
-The script will:
-1. Check prerequisites
-2. Sign in to Azure (`--use-device-code`)
-3. Sign in to Azure Developer CLI
-4. Register resource providers
-5. Ask for GitHub username (optional)
-6. Deploy infrastructure (~5-8 min)
-7. Configure the SRE Agent
-
-### Manual Setup
-
-If you prefer to run each step yourself:
+Run the prereqs script to verify everything is installed:
 
 ```bash
-az login --use-device-code
-azd auth login --use-device-code
-az provider register -n Microsoft.App --wait
+# macOS/Linux
+bash scripts/prereqs.sh
 
+# Windows (Git Bash or CMD)
+"C:\Program Files\Git\bin\bash.exe" scripts/prereqs.sh
+```
+
+### macOS / Linux
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/dm-chelupati/sre-agent-lab.git
+cd sre-agent-lab
+git submodule update --init --recursive
+
+# 2. Sign in to Azure
+az login
+azd auth login
+
+# 3. Create environment and deploy
 azd env new sre-lab
-azd env set AZURE_LOCATION eastus2
-# Optional: azd env set GITHUB_USER <your-username>
+azd up
+# Select your subscription and eastus2 as the region
+```
+
+### Windows
+
+```cmd
+REM 1. Clone the repo (in CMD or PowerShell)
+git clone https://github.com/dm-chelupati/sre-agent-lab.git
+cd sre-agent-lab
+git submodule update --init --recursive
+
+REM 2. Sign in to Azure
+az login
+azd auth login
+
+REM 3. Create environment and deploy
+azd env new sre-lab
 azd up
 
-bash scripts/post-provision.sh
+REM If post-provision fails with 'bash not found' or 'Python not found':
+set PATH=%PATH%;C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python312
+"C:\Program Files\Git\bin\bash.exe" scripts/post-provision.sh
+```
+
+Deployment takes ~8-12 minutes.
+
+## What Gets Deployed
+
+### Azure Infrastructure (via Bicep)
+
+| Resource | Service | Purpose | Docs |
+|----------|---------|---------|------|
+| SRE Agent | `Microsoft.App/agents` | AI agent for incident investigation | [Overview](https://sre.azure.com/docs/overview) |
+| Grubify API | Azure Container Apps | Sample app to monitor | |
+| Grubify Frontend | Azure Container Apps | Sample app UI | |
+| Log Analytics | `Microsoft.OperationalInsights` | Log storage for KQL queries | [Azure Observability](https://sre.azure.com/docs/capabilities/diagnose-azure-observability) |
+| App Insights | `Microsoft.Insights` | Request tracing and exceptions | |
+| Alert Rules | `Microsoft.Insights/metricAlerts` | HTTP 5xx and error log alerts | |
+| Managed Identity | `Microsoft.ManagedIdentity` | Agent identity for Azure access | [Permissions](https://sre.azure.com/docs/tutorials/agent-config/manage-permissions) |
+| Container Registry | `Microsoft.ContainerRegistry` | Grubify container images | |
+
+### RBAC Roles Assigned
+
+| Role | Scope | Purpose |
+|------|-------|---------|
+| SRE Agent Administrator | Agent resource | User can manage agent via data plane APIs | 
+| Reader | Resource group | Agent can read all resources |
+| Monitoring Reader | Resource group | Agent can read metrics and alerts |
+| Log Analytics Reader | Log Analytics workspace | Agent can query logs via KQL |
+
+See: [Manage Permissions](https://sre.azure.com/docs/tutorials/agent-config/manage-permissions)
+
+### SRE Agent Configuration (via post-provision script)
+
+| Component | Purpose | Docs |
+|-----------|---------|------|
+| Knowledge Base | HTTP error runbook, app architecture, incident template | [Memory & Knowledge](https://sre.azure.com/docs/concepts/memory) |
+| incident-handler subagent | Investigates alerts using logs, metrics, runbooks | [Custom Agents](https://sre.azure.com/docs/concepts/subagents) |
+| Response Plan | Routes HTTP 500 alerts to incident-handler | [Response Plans](https://sre.azure.com/docs/capabilities/incident-response-plans) |
+| Azure Monitor | Incident platform — alerts flow to the agent | [Incident Platforms](https://sre.azure.com/docs/concepts/incident-platforms) |
+| GitHub OAuth connector | Code search and issue management (optional) | [Connectors](https://sre.azure.com/docs/concepts/connectors) |
+| code-analyzer subagent | Source code root cause analysis | [Custom Agents](https://sre.azure.com/docs/concepts/subagents) |
+| issue-triager subagent | Automated issue triage from runbook | [Custom Agents](https://sre.azure.com/docs/concepts/subagents) |
+
+> **Note on GitHub tools:** GitHub OAuth tools (code search, issue management) are **built-in native tools**, not MCP tools. Once the GitHub OAuth connector is set up, all agents — including subagents — get access to GitHub tools automatically through global settings. No explicit `mcp_tools` assignment is needed in subagent YAML. This is different from MCP connector tools (Datadog, Splunk, etc.) which require explicit `mcp_tools` assignment.
+| Scheduled Task | Triage customer issues every 12 hours | [Scheduled Tasks](https://sre.azure.com/docs/capabilities/scheduled-tasks) |
+| Code Repo | Agent indexes the Grubify source code | [Deep Context](https://sre.azure.com/docs/concepts/workspace-tools) |
+
+## Post-Deployment
+
+### Re-run the setup script
+
+```bash
+# Full re-run (rebuilds container images + re-uploads everything)
+./scripts/post-provision.sh
+
+# Skip container image builds (just update KB, subagents, response plan)
+./scripts/post-provision.sh --retry
+
+# Windows: run from CMD with Python in PATH
+set PATH=%PATH%;C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python312
+"C:\Program Files\Git\bin\bash.exe" scripts/post-provision.sh --retry
+```
+
+### Manual container deploy (Windows fallback)
+
+If the script deploys images but the app still shows the default page:
+
+```cmd
+for /f "tokens=*" %a in ('azd env get-value AZURE_CONTAINER_REGISTRY_NAME') do set ACR=%a
+for /f "tokens=*" %a in ('azd env get-value CONTAINER_APP_NAME') do set APP=%a
+for /f "tokens=*" %a in ('azd env get-value FRONTEND_APP_NAME') do set FE=%a
+az containerapp update --name %APP% --resource-group rg-sre-lab --image %ACR%.azurecr.io/grubify-api:latest
+az containerapp update --name %FE% --resource-group rg-sre-lab --image %ACR%.azurecr.io/grubify-frontend:latest
 ```
 
 ## Verify Setup
 
-Open [sre.azure.com](https://sre.azure.com) → Full Setup → verify:
-- **Code**: 1 repository (if GitHub connected)
-- **Incidents**: Connected to Azure Monitor
-- **Azure resources**: 1 resource group
-- **Knowledge sources**: runbook files indexed
+After deployment completes, open your agent at [sre.azure.com](https://sre.azure.com) and click **Full setup**. You should see green checkmarks on:
 
-## Scenario 1: IT Operations (No GitHub)
+| Card | Expected Status |
+|------|----------------|
+| **Code** | ✅ 1 repository |
+| **Incidents** | ✅ Connected to Azure Monitor |
+| **Azure resources** | ✅ 1 resource group added |
+| **Knowledge files** | ✅ 1 file |
 
-Break the app and ask the agent to investigate using logs and knowledge base.
+> **Checkpoint:** If any card is missing a checkmark, re-run the post-provision script: `bash scripts/post-provision.sh --retry`
 
-```bash
-# macOS/Linux
-bash scripts/break-app.sh
+Once verified, click **"Done and go to agent"** to open the agent chat and start the team onboarding conversation.
 
-# Windows
-"C:\Program Files\Git\bin\bash.exe" scripts/break-app.sh
-```
+### Team Onboarding
 
-1. Open the Grubify frontend — try adding to cart (it's broken!)
-2. Start a **new chat** → type `/` → select any custom agent
-3. Send:
-   ```
-   The Grubify API is not responding — specifically the "Add to Cart" is failing. 
-   Can you investigate, find the root cause, and create a GitHub issue with your detailed findings?
-   ```
-4. Agent investigates: searches memory, queries KQL, references runbook, identifies memory leak
-5. Ask: `Can you mitigate this issue?`
-6. Verify recovery in browser
+The agent opens a **"Team onboarding"** thread automatically. It will:
 
-> **Automated Alert:** After 10-15 min, check **Activities → Incidents** — Azure Monitor may have fired an alert and the agent investigated autonomously.
+1. **Explore your connected context** — reads the code repository, Azure resources, and knowledge files you connected during setup
+2. **Interview you about your team** — ask about your team structure, on-call rotation, services you own, and escalation paths
 
-## Scenario 2: Developer (Requires GitHub)
+Since the agent already has context from setup, try asking it questions:
 
-Same break as Scenario 1, but the agent also:
-- Searches Grubify source code for the root cause
-- Finds exact file:line causing the memory leak
-- Creates a GitHub issue with code references and fix suggestion
-- May create a PR with the fix
+> *"What do you know about the Grubify app architecture?"*
+>
+> *"Summarize the HTTP errors runbook"*
+>
+> *"What Azure resources are in my resource group?"*
 
-> If the agent can't create an issue, nudge it: `Use the GitHub API to create the issue if the direct tool isn't working`
+The agent saves your team information to persistent memory and references it in every future investigation.
 
-## Scenario 3: Workflow Automation (Requires GitHub)
+> **Tip:** Ask *"What should I do next?"* for personalized recommendations based on what's connected.
+
+## Lab Scenarios
+
+### Scenario 1: IT Operations (No GitHub required)
+
+Break the app and watch the agent investigate:
 
 ```bash
-# Create sample customer issues (uses gh CLI, no PAT needed)
-bash scripts/create-sample-issues.sh <your-user>/grubify
-
-# Or Windows:
-"C:\Program Files\Git\bin\bash.exe" scripts/create-sample-issues.sh <your-user>/grubify
+./scripts/break-app.sh     # macOS/Linux
+# Windows: "C:\Program Files\Git\bin\bash.exe" scripts/break-app.sh
 ```
 
-1. Go to **Builder → Scheduled tasks** → **triage-grubify-issues** → **Run task now**
-2. Check `github.com/<your-user>/grubify/issues` — each `[Customer Issue]` gets:
-   - Classification: Bug, Performance, Feature Request, Question
-   - Labels: `bug`, `api-bug`, `severity-high`, etc.
-   - Triage comment from the agent
+Then open [sre.azure.com](https://sre.azure.com) → Incidents to watch the agent:
+1. Detect the Azure Monitor alert
+2. Query Log Analytics for error patterns
+3. Reference the HTTP errors runbook
+4. Apply remediation (restart/scale)
+5. Summarize with root cause and evidence
 
-## Bonus Scenarios
+### Scenario 2: Developer (Requires GitHub)
 
-### Ask the Agent Anything
+Ask the agent to search source code for root causes:
+- File:line references to problematic code
+- Correlation of production errors to code changes
+- Suggested fixes with before/after examples
 
-Try these prompts in a new chat (no `/agent` needed — the meta agent handles these):
+### Scenario 3: Workflow Automation (Requires GitHub)
 
-```
-What is the public endpoint URL for the Grubify frontend container app?
-```
+Create sample support issues and let the agent triage them:
 
-```
-Show me the CPU and memory usage trends for the Grubify container app over the last hour
-```
-
-```
-Check if there are any Azure Advisor recommendations for my resource group
+```bash
+./scripts/create-sample-issues.sh <owner/repo>
 ```
 
-```
-What recent changes were made to resources in my resource group? Check the Activity Log.
-```
+The agent classifies issues (Documentation, Bug, Feature Request), applies labels, and posts triage comments following the runbook.
 
-### Custom Prompts with Runbook
+## Adding GitHub Later
 
-```
-Using the http-500-errors runbook, walk me through all the diagnostic KQL queries 
-and show me the results for the Grubify app
-```
+After initial setup, add GitHub by signing in via the OAuth URL:
 
-### Team Memory
-
+```bash
+./scripts/setup-github.sh   # macOS/Linux
+# Windows: "C:\Program Files\Git\bin\bash.exe" scripts/setup-github.sh
 ```
-Remember that our on-call rotation is: Monday-Wednesday is Team Alpha, 
-Thursday-Sunday is Team Beta. The escalation path is: on-call → team lead → VP Engineering.
-```
-
-Then later ask: `Who is on call today?`
 
 ## Cleanup
 
@@ -213,18 +250,27 @@ azd down --purge
 
 | Issue | Fix |
 |-------|-----|
-| Python not found (Windows) | Disable Store aliases, reopen CMD |
-| 405 on response plan | Wait 30s, run: `bash scripts/post-provision.sh --retry` |
-| GitHub issue creation fails | Nudge: "Use the GitHub API to create the issue" |
-| `az login` uses wrong account | Run `az logout` then `az login --use-device-code` |
+| `'bash' is not recognized` (Windows) | Run via: `"C:\Program Files\Git\bin\bash.exe" scripts/post-provision.sh` |
+| `Python was not found` (Windows) | Install: `winget install Python.Python.3.12`, disable App execution aliases |
+| `curl: error encountered when reading a file` | Python isn't in Git Bash PATH: `export PATH="$PATH:/c/Users/$USER/AppData/Local/Programs/Python/Python312"` |
+| `roleAssignments/write` denied | Need Owner role on subscription. Check: `az role assignment list --assignee $(az ad signed-in-user show --query id -o tsv)` |
+| `Microsoft.App not registered` | Run: `az provider register -n Microsoft.App --wait` |
+| Grubify shows default page after deploy | Run manual deploy commands (see Post-Deployment section above) |
+| Post-provision 405 on response plan | Wait 30s and run: `./scripts/post-provision.sh --retry` |
 
-## Resources
+## Regions
 
-| Resource | Link |
-|:---------|:-----|
-| **SRE Agent Portal** | [sre.azure.com](https://sre.azure.com) |
-| **Documentation** | [sre.azure.com/docs](https://sre.azure.com/docs) |
-| **Blog** | [aka.ms/sreagent/blog](https://aka.ms/sreagent/blog) |
-| **Labs** | [aka.ms/sreagent/lab](https://aka.ms/sreagent/lab) |
-| **Pricing** | [aka.ms/sreagent/pricing](https://aka.ms/sreagent/pricing) |
-| **Support** | [aka.ms/sreagent/github](https://aka.ms/sreagent/github) |
+SRE Agent is available in: `eastus2`, `swedencentral`, `australiaeast`
+
+## Links
+
+- [Azure SRE Agent Documentation](https://sre.azure.com/docs)
+- [Getting Started Guide](https://sre.azure.com/docs/get-started/create-and-setup)
+- [Connectors](https://sre.azure.com/docs/concepts/connectors)
+- [Custom Agents](https://sre.azure.com/docs/concepts/subagents)
+- [Incident Response](https://sre.azure.com/docs/capabilities/incident-response)
+- [Azure Observability](https://sre.azure.com/docs/capabilities/diagnose-azure-observability)
+
+## License
+
+MIT

--- a/labs/starter-lab/README.md
+++ b/labs/starter-lab/README.md
@@ -257,6 +257,7 @@ azd down --purge
 | `Microsoft.App not registered` | Run: `az provider register -n Microsoft.App --wait` |
 | Grubify shows default page after deploy | Run manual deploy commands (see Post-Deployment section above) |
 | Post-provision 405 on response plan | Wait 30s and run: `./scripts/post-provision.sh --retry` |
+| Agent can't create issues on forked repo | Forks have Issues disabled by default. Enable: repo Settings → Features → Issues ✅, or run `gh api -X PATCH repos/OWNER/REPO -f has_issues=true` |
 
 ## Regions
 

--- a/labs/starter-lab/README.md
+++ b/labs/starter-lab/README.md
@@ -35,7 +35,7 @@ Deploy an Azure SRE Agent connected to a sample application with a single `azd u
 
 ### Optional
 
-- GitHub account (for code search and issue triage scenarios — uses OAuth sign-in, no PAT needed)
+- GitHub account (for code search and issue triage scenarios — uses OAuth sign-in, or a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new) scoped to your fork with `Contents:Read`, `Issues:Read+Write`, `Metadata:Read` for least-privilege access)
 
 ## Quick Start
 
@@ -239,6 +239,14 @@ After initial setup, add GitHub by signing in via the OAuth URL:
 ./scripts/setup-github.sh   # macOS/Linux
 # Windows: "C:\Program Files\Git\bin\bash.exe" scripts/setup-github.sh
 ```
+
+> **Security tip:** The OAuth flow requests broad repo access. For least-privilege,
+> use a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new)
+> scoped to your grubify fork only with permissions: `Contents:Read`, `Issues:Read+Write`, `Metadata:Read`.
+> ```bash
+> export GITHUB_PAT=github_pat_xxxx
+> ./scripts/setup-github.sh
+> ```
 
 ## Cleanup
 

--- a/labs/starter-lab/infra/main.bicep
+++ b/labs/starter-lab/infra/main.bicep
@@ -54,4 +54,3 @@ output CONTAINER_APP_NAME string = resources.outputs.containerAppName
 output FRONTEND_APP_URL string = resources.outputs.frontendAppUrl
 output FRONTEND_APP_NAME string = resources.outputs.frontendAppName
 output LOG_ANALYTICS_WORKSPACE_ID string = resources.outputs.logAnalyticsWorkspaceId
-output APP_INSIGHTS_CONNECTION_STRING string = resources.outputs.appInsightsConnectionString

--- a/labs/starter-lab/infra/modules/sre-agent.bicep
+++ b/labs/starter-lab/infra/modules/sre-agent.bicep
@@ -14,6 +14,7 @@ param identityPrincipalId string
 param appInsightsAppId string
 
 @description('Application Insights Connection String')
+@secure()
 param appInsightsConnectionString string
 
 @description('Application Insights resource ID')

--- a/labs/starter-lab/infra/resources.bicep
+++ b/labs/starter-lab/infra/resources.bicep
@@ -96,4 +96,3 @@ output acrName string = containerApp.outputs.acrName
 output acrLoginServer string = containerApp.outputs.acrLoginServer
 output identityPrincipalId string = identity.outputs.identityPrincipalId
 output logAnalyticsWorkspaceId string = monitoring.outputs.logAnalyticsWorkspaceId
-output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString

--- a/labs/starter-lab/scripts/create-sample-issues.sh
+++ b/labs/starter-lab/scripts/create-sample-issues.sh
@@ -24,6 +24,14 @@ if ! gh auth status &>/dev/null; then
   exit 1
 fi
 
+# Ensure Issues are enabled on the repo (forks have Issues disabled by default)
+if ! gh api "repos/${REPO}" --jq '.has_issues' 2>/dev/null | grep -q true; then
+  echo "   Enabling Issues on ${REPO} (disabled by default on forks)..."
+  gh api -X PATCH "repos/${REPO}" -f has_issues=true > /dev/null 2>&1 \
+    && echo "   ✅ Issues enabled on ${REPO}" \
+    || echo "   ⚠️  Could not enable Issues — enable manually at https://github.com/${REPO}/settings"
+fi
+
 create_issue() {
   local title="$1"
   local body="$2"

--- a/labs/starter-lab/scripts/post-provision.sh
+++ b/labs/starter-lab/scripts/post-provision.sh
@@ -518,6 +518,7 @@ else
   echo "🔗 Step 4/5: GitHub integration... ⏭️  Skipped"
   echo "   No GITHUB_USER set. To enable GitHub integration:"
   echo "   1. Fork https://github.com/dm-chelupati/grubify"
+  echo "      (Enable Issues: Settings → Features → Issues ✅)"
   echo "   2. Run: azd env set GITHUB_USER <your-github-username>"
   echo "   3. Re-run: bash scripts/post-provision.sh --retry"
   echo ""

--- a/labs/starter-lab/scripts/post-provision.sh
+++ b/labs/starter-lab/scripts/post-provision.sh
@@ -491,6 +491,14 @@ if [ -n "$OAUTH_URL" ]; then
   echo "   │  Open this URL in your browser and click 'Authorize'    │"
   echo "   └──────────────────────────────────────────────────────────┘"
   echo ""
+  echo "   ⚠️  Security note: The OAuth flow requests broad repo access."
+  echo "   For least-privilege, you can use a fine-grained PAT instead:"
+  echo "     1. Go to: github.com/settings/personal-access-tokens/new"
+  echo "     2. Scope to your grubify fork only (${GITHUB_REPO})"
+  echo "     3. Set: Contents:Read, Issues:Read+Write, Metadata:Read"
+  echo "     4. Run: ./scripts/setup-github.sh  (with GITHUB_PAT set)"
+  echo "   See: https://github.com/microsoft/sre-agent/issues/113"
+  echo ""
   read -p "   Press Enter after you have authorized in the browser..." _unused
 fi
 

--- a/labs/starter-lab/scripts/setup-github.sh
+++ b/labs/starter-lab/scripts/setup-github.sh
@@ -26,7 +26,13 @@ if [ -z "$GITHUB_PAT" ]; then
   echo "  export GITHUB_PAT=ghp_xxxxxxxxxxxx"
   echo "  ./scripts/setup-github.sh"
   echo ""
-  echo "PAT needs 'repo' scope (Classic) or Contents:Read + Issues:Read/Write (Fine-grained)."
+  echo ""
+  echo "Recommended: Use a fine-grained PAT scoped to your grubify fork only:"
+  echo "  1. Go to: https://github.com/settings/personal-access-tokens/new"
+  echo "  2. Repository access → 'Only select repositories' → your grubify fork"
+  echo "  3. Permissions: Contents:Read, Issues:Read+Write, Metadata:Read"
+  echo ""
+  echo "Alternative: Classic PAT with 'repo' scope (grants access to all repos)."
   exit 1
 fi
 

--- a/samples/bicep-deployment/bicep/minimal-sre-agent.bicep
+++ b/samples/bicep-deployment/bicep/minimal-sre-agent.bicep
@@ -57,6 +57,5 @@ output agentName string = sreAgentResourcesDeployment.outputs.agentName
 output agentId string = sreAgentResourcesDeployment.outputs.agentId
 output agentPortalUrl string = sreAgentResourcesDeployment.outputs.agentPortalUrl
 output userAssignedIdentityId string = sreAgentResourcesDeployment.outputs.userAssignedIdentityId
-output applicationInsightsConnectionString string = sreAgentResourcesDeployment.outputs.applicationInsightsConnectionString
 output logAnalyticsWorkspaceId string = sreAgentResourcesDeployment.outputs.logAnalyticsWorkspaceId
 output createdNewManagedIdentity bool = sreAgentResourcesDeployment.outputs.createdNewManagedIdentity

--- a/samples/bicep-deployment/bicep/sre-agent-resources.bicep
+++ b/samples/bicep-deployment/bicep/sre-agent-resources.bicep
@@ -261,6 +261,5 @@ output agentName string = shouldCreateManagedIdentity ? sreAgentNew.name : sreAg
 output agentId string = shouldCreateManagedIdentity ? sreAgentNew.id : sreAgentExisting.id
 output agentPortalUrl string = 'https://ms.portal.azure.com/#view/Microsoft_Azure_PaasServerless/AgentFrameBlade.ReactView/id/${replace(shouldCreateManagedIdentity ? sreAgentNew.id : sreAgentExisting.id, '/', '%2F')}'
 output userAssignedIdentityId string = shouldCreateManagedIdentity ? userAssignedIdentity.id : existingManagedIdentityId
-output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
 output logAnalyticsWorkspaceId string = logAnalyticsWorkspace.id
 output createdNewManagedIdentity bool = shouldCreateManagedIdentity

--- a/samples/hands-on-lab/infra/main.bicep
+++ b/samples/hands-on-lab/infra/main.bicep
@@ -54,4 +54,3 @@ output CONTAINER_APP_NAME string = resources.outputs.containerAppName
 output FRONTEND_APP_URL string = resources.outputs.frontendAppUrl
 output FRONTEND_APP_NAME string = resources.outputs.frontendAppName
 output LOG_ANALYTICS_WORKSPACE_ID string = resources.outputs.logAnalyticsWorkspaceId
-output APP_INSIGHTS_CONNECTION_STRING string = resources.outputs.appInsightsConnectionString

--- a/samples/hands-on-lab/infra/modules/sre-agent.bicep
+++ b/samples/hands-on-lab/infra/modules/sre-agent.bicep
@@ -14,6 +14,7 @@ param identityPrincipalId string
 param appInsightsAppId string
 
 @description('Application Insights Connection String')
+@secure()
 param appInsightsConnectionString string
 
 @description('Application Insights resource ID')

--- a/samples/hands-on-lab/infra/resources.bicep
+++ b/samples/hands-on-lab/infra/resources.bicep
@@ -96,4 +96,3 @@ output acrName string = containerApp.outputs.acrName
 output acrLoginServer string = containerApp.outputs.acrLoginServer
 output identityPrincipalId string = identity.outputs.identityPrincipalId
 output logAnalyticsWorkspaceId string = monitoring.outputs.logAnalyticsWorkspaceId
-output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString

--- a/samples/proactive-reliability/infrastructure/main.bicep
+++ b/samples/proactive-reliability/infrastructure/main.bicep
@@ -187,6 +187,6 @@ output appServiceName string = appService.name
 output appServiceUrl string = 'https://${appService.properties.defaultHostName}'
 output stagingUrl string = 'https://${appServiceName}-staging.azurewebsites.net'
 output applicationInsightsName string = applicationInsights.name
-output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
-output applicationInsightsInstrumentationKey string = applicationInsights.properties.InstrumentationKey
+// Connection string and instrumentation key are not output to avoid
+// exposing credential-like values in ARM deployment logs (see #86)
 output resourceGroupName string = resourceGroup().name


### PR DESCRIPTION
The root README.md was accidentally overwritten with hands-on lab content (commit 508566d).

**Changes:**
- Restores the original community README (bug reports, feature requests, thread ID instructions)
- Moves the hands-on lab README to `labs/starter-lab/README.md` where it belongs

The lab content is preserved — just relocated to the correct folder.