### PR TITLE
fix: enable Issues on forked repos before creating sample issues (fixes #112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ azd down --purge
 | `Microsoft.App not registered` | Run: `az provider register -n Microsoft.App --wait` |
 | Grubify shows default page after deploy | Run manual deploy commands (see Post-Deployment section above) |
 | Post-provision 405 on response plan | Wait 30s and run: `./scripts/post-provision.sh --retry` |
+| Agent can't create issues on forked repo | Forks have Issues disabled by default. Enable: repo Settings → Features → Issues ✅, or run `gh api -X PATCH repos/OWNER/REPO -f has_issues=true` |
 
 ## Regions
 

--- a/labs/starter-lab/scripts/create-sample-issues.sh
+++ b/labs/starter-lab/scripts/create-sample-issues.sh
@@ -24,6 +24,14 @@ if ! gh auth status &>/dev/null; then
   exit 1
 fi
 
+# Ensure Issues are enabled on the repo (forks have Issues disabled by default)
+if ! gh api "repos/${REPO}" --jq '.has_issues' 2>/dev/null | grep -q true; then
+  echo "   Enabling Issues on ${REPO} (disabled by default on forks)..."
+  gh api -X PATCH "repos/${REPO}" -f has_issues=true > /dev/null 2>&1 \
+    && echo "   ✅ Issues enabled on ${REPO}" \
+    || echo "   ⚠️  Could not enable Issues — enable manually at https://github.com/${REPO}/settings"
+fi
+
 create_issue() {
   local title="$1"
   local body="$2"

--- a/labs/starter-lab/scripts/post-provision.sh
+++ b/labs/starter-lab/scripts/post-provision.sh
@@ -518,6 +518,7 @@ else
   echo "🔗 Step 4/5: GitHub integration... ⏭️  Skipped"
   echo "   No GITHUB_USER set. To enable GitHub integration:"
   echo "   1. Fork https://github.com/dm-chelupati/grubify"
+  echo "      (Enable Issues: Settings → Features → Issues ✅)"
   echo "   2. Run: azd env set GITHUB_USER <your-github-username>"
   echo "   3. Re-run: bash scripts/post-provision.sh --retry"
   echo ""


### PR DESCRIPTION
Forks have GitHub Issues disabled by default, which prevents the SRE Agent from creating issues.

**Changes:**
- `create-sample-issues.sh` now auto-enables Issues via `gh api` before creating sample issues
- `post-provision.sh` skip message reminds users to enable Issues on their fork
- README troubleshooting table documents the workaround

Fixes #112