### PR TITLE
security: recommend fine-grained PAT over broad OAuth scope (fixes #113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Deploy an Azure SRE Agent connected to a sample application with a single `azd u
 
 ### Optional
 
-- GitHub account (for code search and issue triage scenarios — uses OAuth sign-in, no PAT needed)
+- GitHub account (for code search and issue triage scenarios — uses OAuth sign-in, or a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new) scoped to your fork with `Contents:Read`, `Issues:Read+Write`, `Metadata:Read` for least-privilege access)
 
 ## Quick Start
 
@@ -239,6 +239,14 @@ After initial setup, add GitHub by signing in via the OAuth URL:
 ./scripts/setup-github.sh   # macOS/Linux
 # Windows: "C:\Program Files\Git\bin\bash.exe" scripts/setup-github.sh
 ```
+
+> **Security tip:** The OAuth flow requests broad repo access. For least-privilege,
+> use a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new)
+> scoped to your grubify fork only with permissions: `Contents:Read`, `Issues:Read+Write`, `Metadata:Read`.
+> ```bash
+> export GITHUB_PAT=github_pat_xxxx
+> ./scripts/setup-github.sh
+> ```
 
 ## Cleanup
 

--- a/labs/starter-lab/scripts/post-provision.sh
+++ b/labs/starter-lab/scripts/post-provision.sh
@@ -491,6 +491,14 @@ if [ -n "$OAUTH_URL" ]; then
   echo "   │  Open this URL in your browser and click 'Authorize'    │"
   echo "   └──────────────────────────────────────────────────────────┘"
   echo ""
+  echo "   ⚠️  Security note: The OAuth flow requests broad repo access."
+  echo "   For least-privilege, you can use a fine-grained PAT instead:"
+  echo "     1. Go to: github.com/settings/personal-access-tokens/new"
+  echo "     2. Scope to your grubify fork only (${GITHUB_REPO})"
+  echo "     3. Set: Contents:Read, Issues:Read+Write, Metadata:Read"
+  echo "     4. Run: ./scripts/setup-github.sh  (with GITHUB_PAT set)"
+  echo "   See: https://github.com/microsoft/sre-agent/issues/113"
+  echo ""
   read -p "   Press Enter after you have authorized in the browser..." _unused
 fi
 

--- a/labs/starter-lab/scripts/setup-github.sh
+++ b/labs/starter-lab/scripts/setup-github.sh
@@ -26,7 +26,13 @@ if [ -z "$GITHUB_PAT" ]; then
   echo "  export GITHUB_PAT=ghp_xxxxxxxxxxxx"
   echo "  ./scripts/setup-github.sh"
   echo ""
-  echo "PAT needs 'repo' scope (Classic) or Contents:Read + Issues:Read/Write (Fine-grained)."
+  echo ""
+  echo "Recommended: Use a fine-grained PAT scoped to your grubify fork only:"
+  echo "  1. Go to: https://github.com/settings/personal-access-tokens/new"
+  echo "  2. Repository access → 'Only select repositories' → your grubify fork"
+  echo "  3. Permissions: Contents:Read, Issues:Read+Write, Metadata:Read"
+  echo ""
+  echo "Alternative: Classic PAT with 'repo' scope (grants access to all repos)."
   exit 1
 fi
 


### PR DESCRIPTION
GitHub OAuth requests access to all user repos. This adds guidance to use fine-grained PATs scoped to just the grubify fork.

**Changes:**
- `post-provision.sh`: security note after OAuth URL with fine-grained PAT alternative
- `setup-github.sh`: detailed fine-grained PAT instructions (`Contents:Read`, `Issues:Read+Write`, `Metadata:Read`)
- README: updated prerequisites and 'Adding GitHub Later' sections with security tip

Fixes #113