### PR TITLE
security: add @secure() to App Insights connection string params, remove plain-text outputs (fixes #86)

### DIFF
--- a/labs/starter-lab/infra/main.bicep
+++ b/labs/starter-lab/infra/main.bicep
@@ -54,4 +54,3 @@ output CONTAINER_APP_NAME string = resources.outputs.containerAppName
 output FRONTEND_APP_URL string = resources.outputs.frontendAppUrl
 output FRONTEND_APP_NAME string = resources.outputs.frontendAppName
 output LOG_ANALYTICS_WORKSPACE_ID string = resources.outputs.logAnalyticsWorkspaceId
-output APP_INSIGHTS_CONNECTION_STRING string = resources.outputs.appInsightsConnectionString

--- a/labs/starter-lab/infra/modules/sre-agent.bicep
+++ b/labs/starter-lab/infra/modules/sre-agent.bicep
@@ -14,6 +14,7 @@ param identityPrincipalId string
 param appInsightsAppId string
 
 @description('Application Insights Connection String')
+@secure()
 param appInsightsConnectionString string
 
 @description('Application Insights resource ID')

--- a/labs/starter-lab/infra/resources.bicep
+++ b/labs/starter-lab/infra/resources.bicep
@@ -96,4 +96,3 @@ output acrName string = containerApp.outputs.acrName
 output acrLoginServer string = containerApp.outputs.acrLoginServer
 output identityPrincipalId string = identity.outputs.identityPrincipalId
 output logAnalyticsWorkspaceId string = monitoring.outputs.logAnalyticsWorkspaceId
-output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString

--- a/samples/bicep-deployment/bicep/minimal-sre-agent.bicep
+++ b/samples/bicep-deployment/bicep/minimal-sre-agent.bicep
@@ -57,6 +57,5 @@ output agentName string = sreAgentResourcesDeployment.outputs.agentName
 output agentId string = sreAgentResourcesDeployment.outputs.agentId
 output agentPortalUrl string = sreAgentResourcesDeployment.outputs.agentPortalUrl
 output userAssignedIdentityId string = sreAgentResourcesDeployment.outputs.userAssignedIdentityId
-output applicationInsightsConnectionString string = sreAgentResourcesDeployment.outputs.applicationInsightsConnectionString
 output logAnalyticsWorkspaceId string = sreAgentResourcesDeployment.outputs.logAnalyticsWorkspaceId
 output createdNewManagedIdentity bool = sreAgentResourcesDeployment.outputs.createdNewManagedIdentity

--- a/samples/bicep-deployment/bicep/sre-agent-resources.bicep
+++ b/samples/bicep-deployment/bicep/sre-agent-resources.bicep
@@ -261,6 +261,5 @@ output agentName string = shouldCreateManagedIdentity ? sreAgentNew.name : sreAg
 output agentId string = shouldCreateManagedIdentity ? sreAgentNew.id : sreAgentExisting.id
 output agentPortalUrl string = 'https://ms.portal.azure.com/#view/Microsoft_Azure_PaasServerless/AgentFrameBlade.ReactView/id/${replace(shouldCreateManagedIdentity ? sreAgentNew.id : sreAgentExisting.id, '/', '%2F')}'
 output userAssignedIdentityId string = shouldCreateManagedIdentity ? userAssignedIdentity.id : existingManagedIdentityId
-output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
 output logAnalyticsWorkspaceId string = logAnalyticsWorkspace.id
 output createdNewManagedIdentity bool = shouldCreateManagedIdentity

--- a/samples/hands-on-lab/infra/main.bicep
+++ b/samples/hands-on-lab/infra/main.bicep
@@ -54,4 +54,3 @@ output CONTAINER_APP_NAME string = resources.outputs.containerAppName
 output FRONTEND_APP_URL string = resources.outputs.frontendAppUrl
 output FRONTEND_APP_NAME string = resources.outputs.frontendAppName
 output LOG_ANALYTICS_WORKSPACE_ID string = resources.outputs.logAnalyticsWorkspaceId
-output APP_INSIGHTS_CONNECTION_STRING string = resources.outputs.appInsightsConnectionString

--- a/samples/hands-on-lab/infra/modules/sre-agent.bicep
+++ b/samples/hands-on-lab/infra/modules/sre-agent.bicep
@@ -14,6 +14,7 @@ param identityPrincipalId string
 param appInsightsAppId string
 
 @description('Application Insights Connection String')
+@secure()
 param appInsightsConnectionString string
 
 @description('Application Insights resource ID')

--- a/samples/hands-on-lab/infra/resources.bicep
+++ b/samples/hands-on-lab/infra/resources.bicep
@@ -96,4 +96,3 @@ output acrName string = containerApp.outputs.acrName
 output acrLoginServer string = containerApp.outputs.acrLoginServer
 output identityPrincipalId string = identity.outputs.identityPrincipalId
 output logAnalyticsWorkspaceId string = monitoring.outputs.logAnalyticsWorkspaceId
-output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString

--- a/samples/proactive-reliability/infrastructure/main.bicep
+++ b/samples/proactive-reliability/infrastructure/main.bicep
@@ -187,6 +187,6 @@ output appServiceName string = appService.name
 output appServiceUrl string = 'https://${appService.properties.defaultHostName}'
 output stagingUrl string = 'https://${appServiceName}-staging.azurewebsites.net'
 output applicationInsightsName string = applicationInsights.name
-output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
-output applicationInsightsInstrumentationKey string = applicationInsights.properties.InstrumentationKey
+// Connection string and instrumentation key are not output to avoid
+// exposing credential-like values in ARM deployment logs (see #86)
 output resourceGroupName string = resourceGroup().name


### PR DESCRIPTION
The App Insights connection string was exposed as a plain string in Bicep deployment outputs, making it visible in ARM deployment logs.

**Changes across 9 files in 4 directories:**
- Add `@secure()` decorator to `appInsightsConnectionString` params in `sre-agent.bicep`
- Remove `applicationInsightsConnectionString` from top-level `main.bicep` and `resources.bicep` outputs
- Remove `applicationInsightsInstrumentationKey` from proactive-reliability sample outputs

The connection string still flows between modules internally for resource configuration — only the top-level outputs that leak into ARM deployment logs are removed. If needed later, retrieve via: `az monitor app-insights component show --app <name> -g <rg> --query connectionString`

Fixes #86