### PR TITLE
Add GitHub Codespaces devcontainer configuration for Starter Lab

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,55 @@
+{
+  "name": "Azure SRE Agent Lab",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+
+  // --- Dev Container Features ---
+  "features": {
+    // Azure CLI + Bicep
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+      "installBicep": true,
+      "version": "latest"
+    },
+    // Azure Developer CLI (azd)
+    "ghcr.io/azure/azure-dev/azd:latest": {},
+    // Python: system python3 from base image is sufficient (pyyaml via apt)
+    // GitHub CLI (Scenario 3: issue triage)
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    }
+  },
+
+  // --- VS Code Extensions ---
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-bicep",
+        "ms-azuretools.azure-dev",
+        "ms-azuretools.vscode-azure-github-copilot",
+        "ms-vscode.azurecli",
+        "ms-python.python",
+        "redhat.vscode-yaml",
+        "github.copilot-chat"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+
+  // --- Lifecycle Hooks ---
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "postStartCommand": "bash .devcontainer/post-start.sh",
+
+  // --- Azure credentials mount (for local Dev Container use) ---
+  "mounts": [
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.azure,target=/home/vscode/.azure,type=bind,consistency=cached"
+  ],
+
+  // --- Recommended Codespaces machine type ---
+  "hostRequirements": {
+    "cpus": 2,
+    "memory": "4gb"
+  },
+
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# =============================================================================
+# Post-Create Script for Azure SRE Agent Lab Dev Container
+# Runs once when the container is first created.
+# =============================================================================
+set -e
+
+echo "Setting up Azure SRE Agent Lab environment..."
+
+# Install system packages (python3-yaml is pre-compiled, much faster than pip)
+sudo apt-get update && sudo apt-get install -y --no-install-recommends python3-yaml jq
+
+echo "Setup complete."

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# =============================================================================
+# Post-Start Script — runs each time the container starts.
+# =============================================================================
+
+echo ""
+echo "========================================"
+echo "  Azure SRE Agent Lab"
+echo "========================================"
+echo "  Docs: https://aka.ms/sreagent/lab"
+echo "========================================"
+echo ""
+
+# Check Azure login status
+if az account show &>/dev/null; then
+    ACCOUNT=$(az account show --query 'name' -o tsv)
+    echo "Azure: Logged in ($ACCOUNT)"
+else
+    echo "Azure: Not logged in. Run 'az login --use-device-code' to authenticate."
+fi
+echo ""


### PR DESCRIPTION
## Summary

This PR adds a `.devcontainer` configuration to enable GitHub Codespaces support for the Starter Lab (`labs/starter-lab/`), providing a zero-setup development environment for lab participants.

## Files added

- `.devcontainer/devcontainer.json` — Dev container configuration
- `.devcontainer/post-create.sh` — One-time setup script (runs on container creation)
- `.devcontainer/post-start.sh` — Welcome message with login instructions (runs on each terminal open)

## Dev Container Features

| Feature | Purpose |
|---------|---------|
| Azure CLI (with Bicep) | Azure resource management and infrastructure deployment |
| Azure Developer CLI (azd) | `azd up` / `azd down --purge` for deploy and teardown |
| GitHub CLI | Scenario 3: issue triage |

## VS Code extensions

- `ms-azuretools.vscode-bicep`
- `ms-azuretools.azure-dev`
- `ms-azuretools.vscode-azure-github-copilot`
- `ms-vscode.azurecli`
- `ms-python.python`
- `redhat.vscode-yaml`
- `github.copilot-chat`

## Design decisions

- **Base image**: `mcr.microsoft.com/devcontainers/base:ubuntu` — Dev Container-compatible base; system Python 3 from Ubuntu 24.04 is sufficient (no Python Feature needed, avoiding long build times)
- **`python3-yaml` via apt**: Pre-compiled binary instead of `pip install pyyaml` to avoid C extension build time
- **No Docker-in-Docker**: The Starter Lab uses ACR Tasks for container builds, so DinD is not required
- **Host requirements**: 2-core / 4 GB — minimal configuration sufficient for Bicep deployment and shell scripts, minimizing Codespaces billing
- **Azure credential mount**: `~/.azure` bind mount configured for local Dev Container reuse (ignored in Codespaces)

## Quick start (after opening in Codespaces)

```bash
az login --use-device-code
cd labs/starter-lab
bash scripts/setup.sh
```