### PR TITLE
fix: audit cleanup — remove 1P refs, fix broken syntax, update docs

### DIFF
--- a/sreagent-templates/CHANGELOG.md
+++ b/sreagent-templates/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Recipes (3P)
 - `azmon-lawappinsights` — Azure Monitor alert response with App Insights + Log Analytics
 - `pagerduty-law-vmcosmos` — PagerDuty with VM, CosmosDB, HTTP error investigation
-- `dynatrace-mcp` — Dynatrace MCP + webhook bridge + GitHub issue creation
+- `dynatrace-mcp` — Dynatrace MCP connector for app error investigation
 
 ### Core Scripts
 - `new-agent.sh` / `New-Agent.ps1` — interactive or `--non-interactive` recipe setup

--- a/sreagent-templates/CONTRIBUTING.md
+++ b/sreagent-templates/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Azure SRE Agent Awesome Recipes
+# Contributing to Azure SRE Agent Recipes
 
 Thank you for your interest in contributing! We welcome new recipes, improvements to existing ones, and bug fixes.
 

--- a/sreagent-templates/README.md
+++ b/sreagent-templates/README.md
@@ -26,7 +26,7 @@ cd sre-agent/sreagent-templates
 ./bin/new-agent.sh --recipe azmon-lawappinsights --non-interactive \
   --set agentName=my-agent \
   --set resourceGroup=rg-my-agent \
-  --set location=swedencentral \       # or eastus2, uksouth, australiaeast
+  --set location=swedencentral \
   --set targetRGs=rg-my-workload \
   -o my-agent/
 
@@ -55,7 +55,9 @@ Each recipe README has the full parameter list, example values, and post-deploy 
 | `deploy.sh dir/ --dry-run` | Assemble only, no ARM call |
 | `deploy.sh dir/ --what-if` | ARM validation without deploying |
 | `deploy.sh dir/ --force` | Redeploy even if no changes detected |
-| `export-agent.sh --set agentName=clone -o dir/` | Export/clone a live agent |
+| `deploy-tf.sh dir/` | Deploy via Terraform |
+| `clone-agent.sh --from-agent <name> ...` | Clone: export → validate → deploy |
+| `export-agent.sh --set agentName=clone -o dir/` | Export a live agent to config dir |
 | `diff-agent.sh $SUB $RG $AGENT dir/` | Compare config vs live agent |
 | `verify-agent.sh $SUB $RG $AGENT --expected dir/` | 22-point verification |
 
@@ -199,7 +201,7 @@ Full PowerShell 7+ port in [`bin/ps/`](bin/ps/). Same config directory, same res
 
 ## CI/CD
 
-See [examples/ci-cd/](examples/ci-cd/) for GitHub Actions, EV2 pipelines, and step-by-step setup.
+See [examples/ci-cd/](examples/ci-cd/) for GitHub Actions and step-by-step setup.
 
 ## Contributing
 

--- a/sreagent-templates/bicep/Apply-Extras.ps1
+++ b/sreagent-templates/bicep/Apply-Extras.ps1
@@ -7,7 +7,7 @@
 
       1. ARM sub-resources (connectors, incidentFilters, scheduledTasks,
          commonPrompts) — uses `az rest` with management-plane token.
-         Works in Cloud Shell, EV2 pipelines, and PME/AME tenants.
+         Works in Cloud Shell and CI/CD pipelines.
 
       2. Data-plane only (hooks, httpTriggers, repos, knowledge upload)
          — requires token for audience https://azuresre.dev.
@@ -1123,7 +1123,7 @@ if ($DpSkippedItems.Count -gt 0) {
     Write-Host "================================================================"
     Write-Host "  WARNING: $($DpSkippedItems.Count) item(s) skipped (no data-plane token)"
     Write-Host "  These require audience https://azuresre.dev which is not"
-    Write-Host "  available in this environment (Cloud Shell MSI / PME CAP)."
+    Write-Host "  available in this environment (Cloud Shell MSI)."
     Write-Host ""
     Write-Host "  To apply the remaining items:"
     Write-Host "    1. From a compliant machine: az login && re-run this script"

--- a/sreagent-templates/bicep/Assemble-Agent.ps1
+++ b/sreagent-templates/bicep/Assemble-Agent.ps1
@@ -284,7 +284,7 @@ if (Test-Path $connFile -PathType Leaf) {
 $totalConn = $connectors | jq 'length'
 Write-Log "Total: $totalConn connector(s)"
 
-# ═══════ Read config/ (merge main + 1p) ═══════
+# ═══════ Read config/ ═══════
 
 Write-Info 'Assembling config/'
 

--- a/sreagent-templates/bicep/apply-extras.sh
+++ b/sreagent-templates/bicep/apply-extras.sh
@@ -7,7 +7,7 @@
 #
 #   1. ARM sub-resources (connectors, incidentFilters, scheduledTasks,
 #      commonPrompts) — uses `az rest` with management-plane token.
-#      Works in Cloud Shell, EV2 pipelines, and PME/AME tenants.
+#      Works in Cloud Shell and CI/CD pipelines.
 #
 #   2. Data-plane only (hooks, httpTriggers, repos, knowledge upload)
 #      — requires token for audience https://azuresre.dev.
@@ -209,7 +209,7 @@ _dp_token() { az account get-access-token --resource https://azuresre.dev --quer
 echo "Applying extras to ${AGENT} in ${RG}..."
 
 # 1. incidentPlatforms — ARM PATCH on agent resource (not sub-resource PUT)
-# This sets the incident management type (AzMonitor, PagerDuty, ServiceNow, IcM)
+# This sets the incident management type (AzMonitor, PagerDuty, ServiceNow, etc.)
 count=$(jq '.incidentPlatforms // [] | length' "$FILE")
 if [[ "$count" -gt 0 ]]; then
   echo "incidentPlatforms: ${count}"
@@ -872,7 +872,7 @@ if [[ ${#DP_SKIPPED_ITEMS[@]} -gt 0 ]]; then
   echo "══════════════════════════════════════════════════════════════"
   echo "  ⚠ ${#DP_SKIPPED_ITEMS[@]} item(s) skipped (no data-plane token)"
   echo "  These require audience https://azuresre.dev which is not"
-  echo "  available in this environment (Cloud Shell MSI / PME CAP)."
+  echo "  available in this environment (Cloud Shell MSI)."
   echo ""
   echo "  To apply the remaining items:"
   echo "    1. From a compliant machine: az login && re-run this script"

--- a/sreagent-templates/bicep/assemble-agent.sh
+++ b/sreagent-templates/bicep/assemble-agent.sh
@@ -192,7 +192,7 @@ fi
 
 _log "Total: $(echo "$CONNECTORS" | jq 'length') connector(s)"
 
-# ═══════ Read config/ (merge main + 1p) ═══════
+# ═══════ Read config/ ═══════
 
 _info "Assembling config/"
 

--- a/sreagent-templates/bin/clone-agent.sh
+++ b/sreagent-templates/bin/clone-agent.sh
@@ -487,17 +487,11 @@ for i in $(seq 0 $((CONNECTOR_COUNT - 1))); do
     Outlook)
       _warn "Connector '${cname}' (${ctype}): needs PORTAL SETUP — configure Outlook connector via portal API Connections blade"
       ;;
-    IcM)
-      _warn "Connector '${cname}' (${ctype}): needs CERT or MI auth — 1P only. See roles.yaml for setup options"
-      ;;
     PagerDuty)
       _warn "Connector '${cname}' (${ctype}): needs PAGERDUTY API KEY — configure via portal Incident Platforms page"
       ;;
     ServiceNow)
       _warn "Connector '${cname}' (${ctype}): needs SERVICENOW CREDENTIALS — configure via portal Incident Platforms page"
-      ;;
-    Dgrep|GenevaMetrics|Ev2Mcp|S360Mcp)
-      _ok "Connector '${cname}' (${ctype}): 1P connector — uses MI or Key Vault (grant UAMI access after deploy)"
       ;;
     *)
       _warn "Connector '${cname}' (${ctype}): unknown type — verify auth manually in portal"

--- a/sreagent-templates/bin/deploy.sh
+++ b/sreagent-templates/bin/deploy.sh
@@ -427,7 +427,7 @@ if [[ -d "$INPUT" ]]; then
   WH_URL=$(jq -r '.properties.outputs.webhookBridgeTriggerUrl.value // empty' "$TMP" 2>/dev/null)
 
   case "$SCENARIO" in
-    httptrigger-dynatrace)
+    dynatrace-mcp)
       # Try to get the Logic App callback URL
       WH_CALLBACK=$(az rest --method POST \
         --url "/subscriptions/${SUB}/resourceGroups/${RG}/providers/Microsoft.Logic/workflows/${AG}-webhook-bridge/triggers/incoming_webhook/listCallbackUrl?api-version=2019-05-01" \

--- a/sreagent-templates/bin/export-agent.sh
+++ b/sreagent-templates/bin/export-agent.sh
@@ -1051,7 +1051,7 @@ CONNECTORS_CLEAN=$(sanitize "$CONNECTORS_CLEAN")
 
 # ── Write connectors.json ──
 # Toggle-managed types (AppInsights, LogAnalytics, AzureMonitor) go into toggles.
-# All other connectors (MCP, Kusto, IcM, DGrep, Geneva, etc.) go into the connectors array.
+# All other connectors (MCP, Kusto, etc.) go into the connectors array.
 TOGGLE_TYPES="AppInsights|LogAnalytics|AzureMonitor"
 CONNECTORS_ARRAY=$(echo "$CONNECTORS_CLEAN" | jq -c --arg tt "$TOGGLE_TYPES" '[.[] | select(.properties.dataConnectorType | test("^(\($tt))$") | not)]')
 

--- a/sreagent-templates/bin/ps/Deploy-Agent.ps1
+++ b/sreagent-templates/bin/ps/Deploy-Agent.ps1
@@ -745,7 +745,7 @@ if ($IsDirectory) {
         }
 
         switch ($Scenario) {
-            'httptrigger-dynatrace' {
+            'dynatrace-mcp' {
                 # Try to get the Logic App callback URL
                 $WhCallback = ''
                 try {

--- a/sreagent-templates/docs/ARCHITECTURE.md
+++ b/sreagent-templates/docs/ARCHITECTURE.md
@@ -22,6 +22,8 @@ sreagent-templates/
 │   └── ps/                                 ← PowerShell equivalents
 │       ├── New-Agent.ps1
 │       ├── Deploy-Agent.ps1
+│       ├── Deploy-Tf.ps1
+│       ├── Clone-Agent.ps1
 │       ├── Export-Agent.ps1
 │       ├── Diff-Agent.ps1
 │       ├── Verify-Agent.ps1

--- a/sreagent-templates/docs/GETTING-STARTED.md
+++ b/sreagent-templates/docs/GETTING-STARTED.md
@@ -14,7 +14,7 @@ Step-by-step guide to create, deploy, and manage an Azure SRE Agent.
 
 ```bash
 git clone https://github.com/microsoft/sre-agent.git
-cd sreagent-templates
+cd sre-agent/sreagent-templates
 ```
 
 ## Step 2: Choose your path


### PR DESCRIPTION
## Summary

Post-merge audit fixes for sreagent-templates.

### Breaking fix
- **C3**: `deploy.sh` + `Deploy-Agent.ps1` had old `httptrigger-dynatrace` case branch — dynatrace-mcp post-deploy instructions never printed. Fixed.

### Cosmetic/clarity fixes
- **C1**: Remove IcM/Geneva/DGrep/PME/AME/EV2/1P references from scripts (comments + messages visible to 3P users)
- **C2**: Remove "EV2 pipelines" from README (internal-only deployment system)
- **C4**: Fix broken shell syntax in README Quick Start (comment after `\`)
- **C5**: Fix GETTING-STARTED.md `cd` path after clone
- **M3**: Fix CHANGELOG Dynatrace description (still said "webhook bridge")
- **M6**: Add Deploy-Tf.ps1 + Clone-Agent.ps1 to ARCHITECTURE.md tree
- **M7**: Add clone-agent.sh + deploy-tf.sh to README CLI table
- **M9**: Fix CONTRIBUTING.md title ("Awesome Recipes" → "Recipes")
