### PR TITLE
zava-aks-postgres: VNet-injected SRE Agent demo (firewall egress, native kubectl, in-cluster SQL) + custom-metrics correlation + bad-deploy/rollback scenario

### DIFF
--- a/labs/zava-aks-postgres/.github/skills/running-demo/SKILL.md
+++ b/labs/zava-aks-postgres/.github/skills/running-demo/SKILL.md
@@ -131,6 +131,42 @@ If the script aborts with "Telemetry pipeline is dead", the api pods stopped sen
    (mirrors the direct-state checks used in Scenario 1 (`az postgres flexible-server show --query state`) and Scenario 2 (`kubectl get networkpolicy`)).
 2. Navigate to `$storeUrl` — fast loading
 
+## Scenario 4: Bad Deploy / Rollback
+
+### Step 1: Show healthy state
+1. Navigate to `$storeUrl` — confirm healthy, products load
+2. Take screenshot
+
+### Step 2: Break it
+```powershell
+# Ships a bad config rollout: kubectl set env deployment/zava-api FAULT_INJECT=500.
+# This mutates the pod template -> a NEW rollout revision (the deployment signal),
+# and GET /api/products starts returning HTTP 500. Liveness (/livez) and readiness
+# (/api/health) are untouched, so pods stay Running and only the app route regresses.
+# The 1Hz in-cluster self-probe hits /api/products, so the 5xx signal builds with no
+# external load. Verifies AppRequests telemetry is flowing first (-SkipTelemetryCheck
+# to bypass on a brand-new deploy).
+.\.github\skills\running-demo\scripts\break-bad-deploy.ps1
+```
+If the script aborts with "Telemetry pipeline is dead", the api pods stopped sending AppRequests; `kubectl rollout restart deploy/zava-api -n zava-demo` normally fixes it, or pass `-SkipTelemetryCheck`.
+
+### Step 3: Show the break
+1. Navigate to `$storeUrl/api/products` — returns HTTP 500
+2. Navigate to `$storeUrl/api/health` — still `"status":"healthy","db_connected":true` (the deploy regressed the app route, not the DB). Take a screenshot to make the point: platform-healthy, app-broken.
+
+### Step 4: Watch the agent
+1. Check the SRE Agent portal for a new incident from `Zava-http-5xx-errors`
+2. The agent should rule out the DB/network/slow-query conditions, then correlate the 5xx spike with the recent rollout and roll back:
+   ```powershell
+   Invoke-AksCommand -ResourceGroup $rg -ClusterName $aks -Command "kubectl rollout history deployment/zava-api -n zava-demo"
+   ```
+3. Remediation is `kubectl rollout undo deployment/zava-api -n zava-demo` (rollback to the previous good revision)
+4. Do not run `fix-bad-deploy.ps1` as part of the demo — same rule as the other scenarios: the script is post-demo cleanup, not an agent-failure fallback.
+
+### Step 5: Show recovery
+1. Navigate to `$storeUrl/api/products` — returns 200 again
+2. Navigate to `$storeUrl` — products load; take screenshot
+
 ## Watching the SRE Agent
 
 In a separate shell, tail the agent's reasoning live via its data-plane API:
@@ -144,6 +180,7 @@ In a separate shell, tail the agent's reasoning live via its data-plane API:
 - S1 (PG stop): typically 3–5 min
 - S2 (NetworkPolicy): can take 30 min to 3+ hours (it has to investigate the NSG red-herring + pods)
 - S3 (missing index): typically 20–40 min
+- S4 (bad deploy): typically 5–15 min (correlate 5xx with rollout history, then `rollout undo`)
 
 Polling "is the symptom gone yet?" is NOT a valid stall signal. The agent may be deep in investigation. Use `-Tail` to see what it is actually doing — only declare a stall if you see repeated re-investigation with no new actions for a long stretch.
 

--- a/labs/zava-aks-postgres/.github/skills/running-demo/scripts/break-bad-deploy.ps1
+++ b/labs/zava-aks-postgres/.github/skills/running-demo/scripts/break-bad-deploy.ps1
@@ -1,0 +1,78 @@
+#Requires -Version 7.4
+# Break Bad Deploy: Ship a bad config rollout that regresses the product listing.
+#
+# Scenario 4 — Bad Deploy / Rollback (deployment-signal correlation).
+#
+# This simulates the most common real-world incident: a regression introduced by
+# a deployment, not by infra. We flip the app's FAULT_INJECT env var to 500 via
+# `kubectl set env`, which mutates the Deployment's pod template and triggers a
+# NEW rollout revision. That revision IS the deployment signal — the agent is
+# expected to correlate the 5xx spike with `kubectl rollout history` / KubeEvents
+# and roll back with `kubectl rollout undo` (the fix script does the same).
+#
+# Detection reuses the existing Zava-http-5xx-errors metric alert (requests/failed
+# on App Insights). No new alert, no external load generator: the in-cluster 1 Hz
+# self-probe already hits GET /api/products, so once that route returns 500 the
+# failed-request count crosses the threshold on its own. Liveness (/livez) and
+# readiness (/api/health) are deliberately untouched, so pods stay Running and
+# only the app route regresses — exactly the "looks healthy at the platform layer
+# but the app is broken" shape that makes deployment correlation the key signal.
+#
+# AKS is a PRIVATE cluster — every K8s op runs through `az aks command invoke`
+# (via Invoke-AksCommand), the same path the SRE Agent uses for remediation.
+param(
+    [string]$ResourceGroup = "",
+    [string]$ClusterName = "",
+    [string]$Namespace = "zava-demo",
+    # Skip the AppRequests precheck (fail-loud telemetry validator). Only use if
+    # you know the workspace is intentionally empty (e.g. a brand-new deploy
+    # before the api has had time to send any AppRequests).
+    [switch]$SkipTelemetryCheck
+)
+
+$ErrorActionPreference = "Stop"
+. "$PSScriptRoot\..\..\..\..\scripts\_aks-helpers.ps1"
+$ctx = Resolve-AksContext -ResourceGroup $ResourceGroup -ClusterName $ClusterName
+
+# Telemetry precheck. Zava-http-5xx-errors evaluates the requests/failed metric,
+# which is derived from AppRequests telemetry. If the api isn't currently sending
+# telemetry to the workspace, the alert can never fire no matter how many 500s the
+# route returns, and the demo silently fails (looks like "agent ignored an alert"
+# 30 min later). Fail loudly *before* the break. Pass -SkipTelemetryCheck to bypass.
+if (-not $SkipTelemetryCheck) {
+    Write-Host "Verifying telemetry pipeline (AppRequests in last 10 min)..." -ForegroundColor Cyan
+    $ws = (az monitor log-analytics workspace list -g $ctx.ResourceGroup --query "[0].customerId" -o tsv 2>$null)
+    if (-not $ws) {
+        Write-Warning "Could not find Log Analytics workspace in $($ctx.ResourceGroup); skipping telemetry precheck."
+    } else {
+        $kql = "AppRequests | where TimeGenerated > ago(10m) | where AppRoleName == 'zava-api' | summarize n=count()"
+        $raw = (az monitor log-analytics query -w $ws --analytics-query $kql 2>$null)
+        $n = 0
+        if ($raw) { try { $n = [int]((($raw | ConvertFrom-Json)[0].n)) } catch { $n = 0 } }
+        if ($n -lt 1) {
+            Write-Error "Telemetry pipeline is dead: 0 AppRequests from zava-api in the last 10 min. Zava-http-5xx-errors evaluates the requests/failed metric (derived from AppRequests) — without telemetry it can never fire and the SRE Agent will never be dispatched. Possible causes: OTel exporter wedged in api pods, App Insights ingestion throttled, wrong APPLICATIONINSIGHTS_CONNECTION_STRING. Try ``kubectl rollout restart deploy/zava-api -n $Namespace`` to restart the exporter. Pass -SkipTelemetryCheck to override."
+            exit 1
+        }
+        Write-Host "Telemetry OK ($n AppRequests in last 10 min)." -ForegroundColor Green
+    }
+}
+
+# Ship the bad deploy. `kubectl set env` mutates the pod template, which creates a
+# new rollout revision — that revision is the deployment signal the agent should
+# correlate the regression against.
+Write-Host "Shipping bad config rollout: kubectl set env deployment/zava-api FAULT_INJECT=500 ..." -ForegroundColor Red
+$setCmd = "kubectl set env deployment/zava-api FAULT_INJECT=500 -n $Namespace; kubectl rollout status deployment/zava-api -n $Namespace --timeout=180s"
+$r = Invoke-AksCommand -ResourceGroup $ctx.ResourceGroup -ClusterName $ctx.ClusterName -Command $setCmd
+if ($r.exitCode -ne 0) {
+    Write-Error "kubectl set env / rollout status failed (exit $($r.exitCode)). Logs: $($r.logs)"
+    exit 1
+}
+
+Write-Host "Bad deploy rolled out. GET /api/products now returns HTTP 500; /livez and /api/health stay green." -ForegroundColor Yellow
+Write-Host "What to watch:" -ForegroundColor Cyan
+Write-Host "  - Zava-http-5xx-errors metric alert fires (requests/failed > threshold) within ~5 min." -ForegroundColor DarkGray
+Write-Host "  - The SRE Agent should correlate the 5xx spike with the recent rollout:" -ForegroundColor DarkGray
+Write-Host "      kubectl rollout history deployment/zava-api -n $Namespace" -ForegroundColor DarkGray
+Write-Host "      kubectl get events -n $Namespace  (KubeEvents: ScalingReplicaSet)" -ForegroundColor DarkGray
+Write-Host "  - Remediation is a rollback to the previous good revision: kubectl rollout undo." -ForegroundColor DarkGray
+Write-Host "Fix with: .\.github\skills\running-demo\scripts\fix-bad-deploy.ps1" -ForegroundColor Cyan

--- a/labs/zava-aks-postgres/.github/skills/running-demo/scripts/fix-bad-deploy.ps1
+++ b/labs/zava-aks-postgres/.github/skills/running-demo/scripts/fix-bad-deploy.ps1
@@ -1,0 +1,42 @@
+#Requires -Version 7.4
+# Fix Bad Deploy: Roll back the regression that break-bad-deploy.ps1 shipped.
+#
+# Scenario 4 cleanup / agent-failure fallback. The remediation that demonstrates
+# deployment-signal correlation is a rollback to the previous good revision:
+#   kubectl rollout undo deployment/zava-api -n zava-demo
+# This is the same action the SRE Agent runbook permits. `rollout undo` reverts
+# the pod template (dropping FAULT_INJECT=500) and creates a new revision, so the
+# product listing returns to HTTP 200 and the 5xx alert auto-mitigates.
+#
+# We also defensively clear FAULT_INJECT afterwards. If the deployment had
+# multiple revisions and `undo` landed on a revision that still carried the var,
+# `kubectl set env FAULT_INJECT-` guarantees a clean end state (a no-op rollout if
+# already clean).
+#
+# Uses `az aks command invoke` (via Invoke-AksCommand) against the PRIVATE AKS
+# cluster — no kubectl required from the operator's workstation.
+param(
+    [string]$ResourceGroup = "",
+    [string]$ClusterName = "",
+    [string]$Namespace = "zava-demo"
+)
+
+$ErrorActionPreference = "Stop"
+. "$PSScriptRoot\..\..\..\..\scripts\_aks-helpers.ps1"
+$ctx = Resolve-AksContext -ResourceGroup $ResourceGroup -ClusterName $ClusterName
+
+# Preferred remediation: roll back to the previous good revision.
+Write-Host "Rolling back: kubectl rollout undo deployment/zava-api -n $Namespace ..." -ForegroundColor Green
+$undoCmd = "kubectl rollout undo deployment/zava-api -n $Namespace; kubectl rollout status deployment/zava-api -n $Namespace --timeout=180s"
+$r = Invoke-AksCommand -ResourceGroup $ctx.ResourceGroup -ClusterName $ctx.ClusterName -Command $undoCmd
+if ($r.exitCode -ne 0) {
+    Write-Error "kubectl rollout undo / rollout status failed (exit $($r.exitCode)). Logs: $($r.logs)"
+    exit 1
+}
+
+# Defensive: ensure FAULT_INJECT is gone regardless of which revision undo landed on.
+Write-Host "Ensuring FAULT_INJECT is cleared (defensive no-op if already clean)..." -ForegroundColor Green
+$clearCmd = "kubectl set env deployment/zava-api FAULT_INJECT- -n $Namespace; kubectl rollout status deployment/zava-api -n $Namespace --timeout=180s"
+Invoke-AksCommand -ResourceGroup $ctx.ResourceGroup -ClusterName $ctx.ClusterName -Command $clearCmd -Quiet | Out-Null
+
+Write-Host "Rollback complete. GET /api/products returns 200; Zava-http-5xx-errors will auto-mitigate." -ForegroundColor Green

--- a/labs/zava-aks-postgres/README.md
+++ b/labs/zava-aks-postgres/README.md
@@ -22,10 +22,10 @@ azd down --force --purge     # Tear down when done
 |-----------|---------|
 | **App** | Zava Athletic e-commerce storefront (Node.js/Express on AKS) |
 | **Database** | PostgreSQL 16 Flexible Server (Entra-only auth, zero passwords) |
-| **Monitoring** | App Insights + Log Analytics (4-day retention on noisy tables, no daily ingestion cap, 100% sampling; probes filtered at the alert KQL so alerts fire fast) + 8 Azure Monitor alert rules |
+| **Monitoring** | App Insights + Log Analytics (4-day retention on noisy tables, no daily ingestion cap, 100% sampling; probes filtered at the alert KQL so alerts fire fast) + 10 Azure Monitor alert rules. The app emits a **custom OpenTelemetry metric** (`zava.products.category.query.duration_ms` + a `slow_query` counter) so latency regressions surface as a first-class **metric** signal — not just logs/traces — and a PostgreSQL `cpu_percent` metric alert covers DB saturation. |
 | **SRE Agent** | Anthropic-backed agent (Preview channel). Connectors, skills, response plans, and Azure Monitor incident binding declared in `infra/modules/sre-agent.bicep`. Knowledge-file upload via `scripts/setup-sre-agent.ps1` (ARM doesn't surface that yet). Default agent + rich skills, no subagent handoff. |
 | **Telemetry access** | App Insights, Log Analytics, and Azure Monitor exposed via **connectors** |
-| **Demo Scenarios** | 3 break/fix scenarios with scripts |
+| **Demo Scenarios** | 4 break/fix scenarios with scripts |
 
 ## Architecture
 
@@ -35,7 +35,10 @@ azd down --force --purge     # Tear down when done
 │                                                                 │
 │  ┌──────────┐     ┌───────────────────────────┐                 │
 │  │ SRE Agent│◄────│  Azure Monitor Alerts (8) │                 │
-│  └────┬─────┘     └─────────┬─────────────────┘                 │
+│  │ (VNet-   │     └─────────┬─────────────────┘                 │
+│  │  injected│               │     egress → Azure Firewall       │
+│  │  +FW lock│               │     (default-deny allow-list)     │
+│  └────┬─────┘               │                                   │
 │       │                     │                                   │
 │       ▼                     │                                   │
 │  ┌─────────────────────┐    │    ┌────────────────────┐         │
@@ -83,9 +86,22 @@ While the UI shows `agent investigating`, the SRE Agent is actually working the 
 ### Scenario 3: Missing Index
 ```powershell
 .\.github\skills\running-demo\scripts\break-db-perf.ps1  # Drops category/name index → slow queries
-# Agent detects response time degradation via App Insights
+# Two correlated signals fire for one root cause: the custom-metric alert
+# (Zava-category-latency-metric, on zava.products.category.query.duration_ms) AND
+# the log alert (Zava-products-query-slow); PG cpu saturation may co-fire. The agent
+# correlates logs + metrics + traces and applies CREATE INDEX via the in-cluster helper.
 .\.github\skills\running-demo\scripts\fix-db-perf.ps1    # Fallback
 ```
+
+### Scenario 4: Bad Deploy / Rollback
+```powershell
+.\.github\skills\running-demo\scripts\break-bad-deploy.ps1  # kubectl set env FAULT_INJECT=500 → new rollout, GET /api/products returns 500
+# Existing Zava-http-5xx-errors alert fires; agent correlates the 5xx spike with the recent
+# rollout (kubectl rollout history / KubeEvents) and rolls back to the previous good revision.
+.\.github\skills\running-demo\scripts\fix-bad-deploy.ps1    # Fallback: kubectl rollout undo
+```
+Liveness (`/livez`) and readiness (`/api/health`) stay green, so the platform looks healthy while
+only the app route regresses — deployment-signal correlation is what ties the symptom to its cause.
 
 ## SRE Agent Management
 
@@ -100,14 +116,18 @@ Drop new `*.md` files into `sre-config/knowledge-base/` and re-run the script to
 
 ## How the Agent Operates Against a Private Backend
 
-### Design constraint: no VNet injection, no direct AKS/PG access
+### Network posture: VNet-injected, egress locked down behind an Azure Firewall
 
-This sample is built to a deliberate constraint: **the agent works entirely through the Azure control plane (ARM), with no VNet injection and no direct network reachability to AKS or PostgreSQL.** It runs in a Microsoft-managed network and never sees the app VNet. The point is portability — this pattern works in fully locked-down customer environments where opening the VNet to a managed agent isn't on the table.
+The agent is **injected into the workload VNet** (a delegated `agent-subnet`) and its sandbox egress is **locked down behind an Azure Firewall** — default-deny, with an allow-list of exactly what it needs (ARM, Entra, Microsoft Graph, Azure Monitor, and Microsoft Learn). Because it sits **inside** the VNet, it works the private AKS API server and private PostgreSQL with its **own managed identity** — native kubectl for the cluster, and SQL through an in-cluster helper — while ARM and Azure Monitor go over the control plane. The firewall permits exactly those endpoints and nothing else gets out. The point is a fully locked-down, in-VNet agent: it sits inside the customer network boundary yet its blast radius is constrained to the Azure endpoints on the allow-list and its least-privilege identity grants.
 
-One consequence is worth calling out, because it shapes Scenario 3's remediation: **DDL like `CREATE INDEX` is data-plane only.** No managed PG service (Azure PG Flex, RDS, Cloud SQL) exposes catalog mutation through its cloud control plane — `az postgres flexible-server execute` and friends are just libpq clients embedded in the CLI and need network reachability. So the agent runs DDL by tunneling through a workload that's already in the VNet — the api pod:
+> **What "VNet-injected" means here:** the agent's sandbox has **L7 HTTP(S) egress to allow-listed destinations, not raw L3/L4 network access**. It makes HTTPS calls to the allow-listed endpoints (ARM, Entra, Azure Monitor, Microsoft Learn, and any registry added via `allowedRegistries`); it does not open raw TCP/UDP sockets to private VNet IPs. Anything that needs a direct private connection — a database or other non-HTTP service — runs from a workload with a real VNet NIC (an in-cluster pod via `kubectl exec`). `kubectl` and `az` operate over the Kubernetes and ARM **control planes** (HTTP), so they work from the sandbox directly. Egress allow/deny decisions are visible in the SRE Agent UI under **Workspace Configuration → Inspect → Network audit** (Preview).
+
+> **Scope:** the firewall + forced-tunnel route govern the **agent sandbox's internet egress** (the `agent-subnet` only). They do not restrict private intra-VNet traffic, the AKS subnet's own egress, or what the agent can make AKS do via its Cluster Admin RBAC — those are governed by Kubernetes RBAC and the agent's action boundary, not this firewall.
+
+One consequence is worth calling out, because it shapes Scenario 3's remediation: **DDL like `CREATE INDEX` is data-plane only.** No managed PG service (Azure PG Flex, RDS, Cloud SQL) exposes catalog mutation through its cloud control plane. The agent reads `pg_stat_*` to diagnose the missing index and applies the DDL the same way — by running the in-cluster helper from a workload that's already in the VNet (the api pod) through its native kubectl tool:
 
 ```
-az aks command invoke … kubectl exec deploy/zava-api -- node bin/run-sql.js "<SQL>"
+RunKubectlWriteCommand → kubectl exec deploy/zava-api -n zava-demo -- node bin/run-sql.js "<SQL>"
 ```
 
 `bin/run-sql.js` is ~30 lines: a `pg`-client wrapper that reuses the pod's existing workload identity (already a PG Entra admin). No new endpoint, no new identity, no temporary network opening — just reuses an existing trust path.
@@ -115,19 +135,27 @@ az aks command invoke … kubectl exec deploy/zava-api -- node bin/run-sql.js "<
 | Component | Endpoint | How the agent works on it |
 |---|---|---|
 | Storefront / nginx ingress | Public LoadBalancer IP | HTTP from anywhere |
-| AKS API server | **Private** (system-managed private DNS zone) | `az aks command invoke` (Azure proxies the command through the AKS control plane; both agent identities hold *Cluster Admin* RBAC) |
-| Pods, services, node IPs | Private (VNet only) | `az aks command invoke … kubectl <verb>` (`get`, `logs`, `describe`, `delete`, `apply`, `exec`, `rollout`) |
-| PostgreSQL Flex (port 5432) | **Private only** — `publicNetworkAccess: Disabled`, VNet-delegated | `az postgres flexible-server` (state/config) and `az aks command invoke … kubectl exec deploy/zava-api -- node bin/run-sql.js "<SQL>"` (in-cluster SQL through an app pod's identity — the image ships `bin/run-sql.js`, not `psql`) |
+| AKS API server | **Private** (system-managed private DNS zone) | Native kubectl (`RunKubectlReadCommand` / `RunKubectlWriteCommand`) authenticated by the agent's Entra identity (*Cluster Admin* RBAC) |
+| Pods, services, node IPs | Private (VNet only) | Native `kubectl <verb>` (`get`, `logs`, `describe`, `delete`, `apply`, `exec`, `rollout`) |
+| PostgreSQL Flex (port 5432) | **Private only** — `publicNetworkAccess: Disabled`, VNet-delegated | State/config: `az postgres flexible-server`. SQL (reads + DDL): `kubectl exec deploy/zava-api -- node bin/run-sql.js "<SQL>"` via **native kubectl** (the in-cluster helper reuses the pod's PG Entra identity) |
 
-### What the agent can do via the control plane (no VNet injection required)
+### What the agent can do (from inside the locked-down VNet)
 
 | Plane | Read | Write / remediate |
 |---|---|---|
 | **AKS control plane** | `az aks show / nodepool list / get-upgrades` | `az aks start / stop / update / nodepool scale / rotate-certs` |
-| **AKS in-cluster proxy** (`az aks command invoke`) | `kubectl get …`, `kubectl logs`, `kubectl describe` | `kubectl delete networkpolicy …` (Scenario 2), `kubectl rollout restart …`, `kubectl exec deploy/zava-api -- node bin/run-sql.js "CREATE INDEX …"` (Scenario 3) |
-| **PostgreSQL control plane** | `az postgres flexible-server show / parameter list / backup list / server-logs list / replica list` | `az postgres flexible-server start` (**Scenario 1**), `restart`, `update`, `parameter set`, `replica create`, `restore`, `ad-admin create` |
+| **Kubernetes (native kubectl)** | `RunKubectlReadCommand` — `kubectl get …`, `logs`, `describe` | `RunKubectlWriteCommand` — `kubectl delete networkpolicy …` (Scenario 2), `kubectl rollout restart …`, `kubectl exec deploy/zava-api -- node bin/run-sql.js "CREATE INDEX …"` (Scenario 3) |
+| **PostgreSQL** | Control: `az postgres flexible-server show / parameter list / backup list / server-logs list / replica list`. Data (reads + DDL): `kubectl exec … bin/run-sql.js` via native kubectl | `az postgres flexible-server start` (**Scenario 1**), `restart`, `update`, `parameter set`, `replica create`, `restore`, `ad-admin create` |
 | **Networking** | `az network nsg / vnet / private-dns show` | `az network nsg rule create / delete` (Scenario 2 cleanup) |
 | **Telemetry** | App Insights, Log Analytics, and Azure Monitor connectors (KQL + metrics) — API-based, no network reachability needed | Alert / action group create / update |
+
+### Running PostgreSQL SQL
+
+SQL — reads (`pg_stat_*`) and read-mostly DDL like `CREATE INDEX CONCURRENTLY` and `ANALYZE` — runs through the in-cluster `bin/run-sql.js` helper in the application pod, which reuses the pod's PostgreSQL Entra identity:
+
+```
+kubectl exec deploy/zava-api -n zava-demo -- node bin/run-sql.js "<SQL>"
+```
 
 ### Practical limits
 
@@ -164,7 +192,7 @@ mergeWindowHours: 0
 - [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) (1.9+)
 - [PowerShell 7.4+](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) — **required on Windows, WSL, Linux, or macOS**; `azd up` runs a pre-provision check and fast-fails if `pwsh` is missing
 
-> **Note:** `kubectl` is **not** required on your local workstation. The AKS cluster is private; operator in-cluster operations in this repo go through `az aks command invoke` (wrapped by `Invoke-AksCommand` in `scripts/_aks-helpers.ps1`), and the SRE Agent reaches the cluster the same way via its `az` CLI tools (Azure RBAC Cluster Admin granted in Bicep).
+> **Note:** `kubectl` is **not** required on your local workstation. The AKS cluster is private; operator in-cluster operations in this repo go through `az aks command invoke` (wrapped by `Invoke-AksCommand` in `scripts/_aks-helpers.ps1`). The SRE Agent, by contrast, is VNet-injected and uses its own **native kubectl tools** (Entra / managed-identity auth) — see "How the Agent Operates Against a Private Backend" above.
 
 > **Region default:** `azd up` will prompt for a location. The Bicep default is `swedencentral` (validated end-to-end there). To deploy elsewhere, pick another region at the prompt or run `azd env set AZURE_LOCATION <region>` before `azd up`. Any region with availability for AKS, PostgreSQL Flexible Server, and the SRE Agent resource provider works.
 

--- a/labs/zava-aks-postgres/infra/main.bicep
+++ b/labs/zava-aks-postgres/infra/main.bicep
@@ -101,6 +101,7 @@ module sreAgent 'modules/sre-agent.bicep' = {
     logAnalyticsId: monitoring.outputs.logAnalyticsWorkspaceId
     managedResourceGroupId: rg.id
     aksClusterName: aks.outputs.clusterName
+    agentSubnetId: vnet.outputs.agentSubnetId
   }
 }
 

--- a/labs/zava-aks-postgres/infra/main.bicepparam
+++ b/labs/zava-aks-postgres/infra/main.bicepparam
@@ -1,7 +1,7 @@
 using './main.bicep'
 
 param location = 'swedencentral'
-param resourceGroupName = 'rg-zava-aks-postgres'
+param resourceGroupName = readEnvironmentVariable('ZAVA_RG_NAME', 'rg-zava-aks-postgres')
 
 // AZD sets AZURE_ENV_NAME automatically (e.g. 'zava-oneshot-1514'). Read it
 // here so the per-env SRE Agent suffix is derivable at deployment-plan time.

--- a/labs/zava-aks-postgres/infra/main.json
+++ b/labs/zava-aks-postgres/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "10212371151939919113"
+      "version": "0.43.1.21952",
+      "templateHash": "4890042339973748602"
     }
   },
   "parameters": {
@@ -72,8 +72,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "16572089972785666489"
+              "version": "0.43.1.21952",
+              "templateHash": "11890560791397435576"
             }
           },
           "parameters": {
@@ -92,7 +92,8 @@
           },
           "variables": {
             "vnetName": "[format('vnet-Zava-{0}', parameters('uniqueSuffix'))]",
-            "nsgName": "[format('nsg-aks-{0}', parameters('uniqueSuffix'))]"
+            "nsgName": "[format('nsg-aks-{0}', parameters('uniqueSuffix'))]",
+            "firewallPrivateIp": "10.3.1.4"
           },
           "resources": [
             {
@@ -113,6 +114,38 @@
                       "sourcePortRange": "*",
                       "destinationAddressPrefix": "*",
                       "destinationPortRange": "*"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Network/publicIPAddresses",
+              "apiVersion": "2024-05-01",
+              "name": "[format('afw-pip-Zava-{0}', parameters('uniqueSuffix'))]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Standard",
+                "tier": "Regional"
+              },
+              "properties": {
+                "publicIPAllocationMethod": "Static"
+              }
+            },
+            {
+              "type": "Microsoft.Network/routeTables",
+              "apiVersion": "2024-05-01",
+              "name": "[format('rt-agent-{0}', parameters('uniqueSuffix'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "disableBgpRoutePropagation": true,
+                "routes": [
+                  {
+                    "name": "default-to-azure-firewall",
+                    "properties": {
+                      "addressPrefix": "0.0.0.0/0",
+                      "nextHopType": "VirtualAppliance",
+                      "nextHopIpAddress": "[variables('firewallPrivateIp')]"
                     }
                   }
                 ]
@@ -157,10 +190,34 @@
                         }
                       ]
                     }
+                  },
+                  {
+                    "name": "agent-subnet",
+                    "properties": {
+                      "addressPrefix": "10.3.0.0/27",
+                      "routeTable": {
+                        "id": "[resourceId('Microsoft.Network/routeTables', format('rt-agent-{0}', parameters('uniqueSuffix')))]"
+                      },
+                      "delegations": [
+                        {
+                          "name": "agent-delegation",
+                          "properties": {
+                            "serviceName": "Microsoft.App/environments"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "AzureFirewallSubnet",
+                    "properties": {
+                      "addressPrefix": "10.3.1.0/26"
+                    }
                   }
                 ]
               },
               "dependsOn": [
+                "[resourceId('Microsoft.Network/routeTables', format('rt-agent-{0}', parameters('uniqueSuffix')))]",
                 "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
               ]
             },
@@ -185,6 +242,182 @@
                 "[resourceId('Microsoft.Network/privateDnsZones', format('{0}.private.postgres.database.azure.com', parameters('uniqueSuffix')))]",
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
               ]
+            },
+            {
+              "type": "Microsoft.Network/firewallPolicies",
+              "apiVersion": "2024-05-01",
+              "name": "[format('afw-policy-Zava-{0}', parameters('uniqueSuffix'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "sku": {
+                  "tier": "Standard"
+                },
+                "dnsSettings": {
+                  "enableProxy": true
+                },
+                "threatIntelMode": "Deny"
+              }
+            },
+            {
+              "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+              "apiVersion": "2024-05-01",
+              "name": "[format('{0}/{1}', format('afw-policy-Zava-{0}', parameters('uniqueSuffix')), 'DefaultNetworkRuleCollectionGroup')]",
+              "properties": {
+                "priority": 200,
+                "ruleCollections": [
+                  {
+                    "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+                    "name": "allow-essential-dns",
+                    "priority": 100,
+                    "action": {
+                      "type": "Allow"
+                    },
+                    "rules": [
+                      {
+                        "ruleType": "NetworkRule",
+                        "name": "allow-azure-dns",
+                        "description": "DNS resolution via Azure DNS (required for the firewall DNS proxy)",
+                        "ipProtocols": [
+                          "UDP",
+                          "TCP"
+                        ],
+                        "sourceAddresses": [
+                          "10.3.0.0/27"
+                        ],
+                        "destinationAddresses": [
+                          "168.63.129.16"
+                        ],
+                        "destinationPorts": [
+                          "53"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+                    "name": "allow-azure-service-tags",
+                    "priority": 105,
+                    "action": {
+                      "type": "Allow"
+                    },
+                    "rules": [
+                      {
+                        "ruleType": "NetworkRule",
+                        "name": "allow-azure-services-l4",
+                        "description": "L4 access to Azure services via precise service tags (NOT AzureCloud)",
+                        "ipProtocols": [
+                          "TCP"
+                        ],
+                        "sourceAddresses": [
+                          "10.3.0.0/27"
+                        ],
+                        "destinationAddresses": [
+                          "AzureResourceManager",
+                          "AzureActiveDirectory",
+                          "AzureMonitor"
+                        ],
+                        "destinationPorts": [
+                          "443"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+                    "name": "allow-agent-azure-services",
+                    "priority": 150,
+                    "action": {
+                      "type": "Allow"
+                    },
+                    "rules": [
+                      {
+                        "ruleType": "ApplicationRule",
+                        "name": "allow-arm-aad-graph",
+                        "description": "FQDN access to ARM, Entra ID, and Microsoft Graph",
+                        "sourceAddresses": [
+                          "10.3.0.0/27"
+                        ],
+                        "protocols": [
+                          {
+                            "protocolType": "Https",
+                            "port": 443
+                          }
+                        ],
+                        "targetFqdns": [
+                          "management.azure.com",
+                          "login.microsoftonline.com",
+                          "graph.microsoft.com"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+                    "name": "allow-microsoft-learn",
+                    "priority": 200,
+                    "action": {
+                      "type": "Allow"
+                    },
+                    "rules": [
+                      {
+                        "ruleType": "ApplicationRule",
+                        "name": "allow-learn-microsoft-com",
+                        "description": "Microsoft Learn docs + MCP (the agent looks up Azure/AKS/PostgreSQL guidance here)",
+                        "sourceAddresses": [
+                          "10.3.0.0/27"
+                        ],
+                        "protocols": [
+                          {
+                            "protocolType": "Https",
+                            "port": 443
+                          }
+                        ],
+                        "targetFqdns": [
+                          "learn.microsoft.com",
+                          "*.learn.microsoft.com"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/firewallPolicies', format('afw-policy-Zava-{0}', parameters('uniqueSuffix')))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/azureFirewalls",
+              "apiVersion": "2024-05-01",
+              "name": "[format('afw-Zava-{0}', parameters('uniqueSuffix'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "sku": {
+                  "name": "AZFW_VNet",
+                  "tier": "Standard"
+                },
+                "firewallPolicy": {
+                  "id": "[resourceId('Microsoft.Network/firewallPolicies', format('afw-policy-Zava-{0}', parameters('uniqueSuffix')))]"
+                },
+                "ipConfigurations": [
+                  {
+                    "name": "fw-ipconfig",
+                    "properties": {
+                      "subnet": {
+                        "id": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '2024-01-01').subnets[3].id]"
+                      },
+                      "publicIPAddress": {
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('afw-pip-Zava-{0}', parameters('uniqueSuffix')))]"
+                      }
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', format('afw-pip-Zava-{0}', parameters('uniqueSuffix')))]",
+                "[resourceId('Microsoft.Network/firewallPolicies', format('afw-policy-Zava-{0}', parameters('uniqueSuffix')))]",
+                "[resourceId('Microsoft.Network/firewallPolicies/ruleCollectionGroups', format('afw-policy-Zava-{0}', parameters('uniqueSuffix')), 'DefaultNetworkRuleCollectionGroup')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
+              ]
             }
           ],
           "outputs": {
@@ -203,6 +436,10 @@
             "dbSubnetId": {
               "type": "string",
               "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '2024-01-01').subnets[1].id]"
+            },
+            "agentSubnetId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '2024-01-01').subnets[2].id]"
             },
             "nsgName": {
               "type": "string",
@@ -243,8 +480,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "17028242685811391999"
+              "version": "0.43.1.21952",
+              "templateHash": "16542703906130965193"
             }
           },
           "parameters": {
@@ -328,8 +565,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "7326506129800277627"
+              "version": "0.43.1.21952",
+              "templateHash": "5864804151585967659"
             }
           },
           "parameters": {
@@ -728,6 +965,85 @@
               ]
             },
             {
+              "type": "Microsoft.Insights/scheduledQueryRules",
+              "apiVersion": "2023-03-15-preview",
+              "name": "Zava-category-latency-metric",
+              "location": "[parameters('location')]",
+              "properties": {
+                "severity": 2,
+                "enabled": true,
+                "evaluationFrequency": "PT1M",
+                "windowSize": "PT5M",
+                "scopes": [
+                  "[resourceId('Microsoft.OperationalInsights/workspaces', variables('lawName'))]"
+                ],
+                "criteria": {
+                  "allOf": [
+                    {
+                      "query": "AppMetrics\r\n| where AppRoleName == 'zava-api'\r\n| where Name == 'zava.products.category.query.duration_ms'\r\n| extend Category = tostring(Properties['category'])\r\n| where Category != '__probe'\r\n| summarize AvgDurationMs = sum(Sum) / sum(ItemCount) by Category\r\n| where AvgDurationMs > 30",
+                      "timeAggregation": "Count",
+                      "operator": "GreaterThan",
+                      "threshold": 0,
+                      "failingPeriods": {
+                        "numberOfEvaluationPeriods": 1,
+                        "minFailingPeriodsToAlert": 1
+                      }
+                    }
+                  ]
+                },
+                "actions": {
+                  "actionGroups": [
+                    "[resourceId('Microsoft.Insights/actionGroups', format('ag-Zava-sre-{0}', parameters('uniqueSuffix')))]"
+                  ]
+                },
+                "autoMitigate": true,
+                "description": "Zava Demo: the zava.products.category.query.duration_ms custom metric averaged above 30ms for at least one category over 5 minutes (healthy baseline ~3ms)."
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Insights/actionGroups', format('ag-Zava-sre-{0}', parameters('uniqueSuffix')))]",
+                "[resourceId('Microsoft.OperationalInsights/workspaces', variables('lawName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Insights/metricAlerts",
+              "apiVersion": "2018-03-01",
+              "name": "Zava-db-cpu-saturation",
+              "location": "global",
+              "properties": {
+                "severity": 3,
+                "enabled": true,
+                "scopes": [
+                  "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('postgresServerName'))]"
+                ],
+                "evaluationFrequency": "PT1M",
+                "windowSize": "PT5M",
+                "criteria": {
+                  "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                  "allOf": [
+                    {
+                      "name": "pgCpu",
+                      "metricName": "cpu_percent",
+                      "metricNamespace": "Microsoft.DBforPostgreSQL/flexibleServers",
+                      "operator": "GreaterThan",
+                      "threshold": 80,
+                      "timeAggregation": "Average",
+                      "criterionType": "StaticThresholdCriterion"
+                    }
+                  ]
+                },
+                "actions": [
+                  {
+                    "actionGroupId": "[resourceId('Microsoft.Insights/actionGroups', format('ag-Zava-sre-{0}', parameters('uniqueSuffix')))]"
+                  }
+                ],
+                "autoMitigate": true,
+                "description": "Zava Demo: PostgreSQL server CPU averaged above 80% over 5 minutes."
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Insights/actionGroups', format('ag-Zava-sre-{0}', parameters('uniqueSuffix')))]"
+              ]
+            },
+            {
               "type": "Microsoft.Insights/activityLogAlerts",
               "apiVersion": "2023-01-01-preview",
               "name": "postgres-server-stopped",
@@ -830,8 +1146,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13272948923324719539"
+              "version": "0.43.1.21952",
+              "templateHash": "10431586641767226171"
             }
           },
           "parameters": {
@@ -1039,8 +1355,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "1619425297672132838"
+              "version": "0.43.1.21952",
+              "templateHash": "4471309822927703249"
             }
           },
           "parameters": {
@@ -1211,8 +1527,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "8609693906669799130"
+              "version": "0.43.1.21952",
+              "templateHash": "3222822890112493357"
             }
           },
           "parameters": {
@@ -1397,6 +1713,9 @@
           },
           "aksClusterName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'aks'), '2025-04-01').outputs.clusterName.value]"
+          },
+          "agentSubnetId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'vnet'), '2025-04-01').outputs.agentSubnetId.value]"
           }
         },
         "template": {
@@ -1405,8 +1724,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "9260401994940964470"
+              "version": "0.43.1.21952",
+              "templateHash": "4407083482938427939"
             }
           },
           "parameters": {
@@ -1464,6 +1783,12 @@
                 "description": "AKS cluster name — used to grant system identity K8s-level RBAC"
               }
             },
+            "agentSubnetId": {
+              "type": "string",
+              "metadata": {
+                "description": "Resource ID of the VNet-injection subnet (delegated to Microsoft.App/environments). The agent sandbox runs here with egress forced through the Azure Firewall."
+              }
+            },
             "modelProvider": {
               "type": "string",
               "defaultValue": "Anthropic",
@@ -1504,12 +1829,16 @@
               "tools": [
                 "RunAzCliReadCommands",
                 "RunAzCliWriteCommands",
+                "RunKubectlReadCommand",
+                "RunKubectlWriteCommand",
+                "RunKubectlCommandHelp",
+                "RunInTerminal",
                 "SearchMemory",
                 "microsoft-learn_microsoft_code_sample_search",
                 "microsoft-learn_microsoft_docs_fetch",
                 "microsoft-learn_microsoft_docs_search"
               ],
-              "skillContent": "## Zava Incident Runbook\r\n\r\nResource Group: `@@RG@@`. App Insights `cloud_RoleName`: `zava-api`. App k8s namespace: `zava-demo`.\r\n\r\nYou diagnose from telemetry, then remediate within the permitted-action boundary below. Outside that boundary you summarize and stop. When in doubt about an Azure / AKS / PostgreSQL surface you haven't seen before, look it up in Microsoft Learn before guessing.\r\n\r\n## Tools you have\r\n\r\n- **`az` CLI (read + write)** — your only Azure interface. For in-cluster operations (kubectl, exec, SQL through the app pod), the path is `az aks command invoke`.\r\n- **Memory search** — past investigations and the architecture knowledge base.\r\n- **Microsoft Learn search/fetch** — for Azure / AKS / PostgreSQL Flexible Server / KQL surfaces you're unsure about. Prefer documenting your reasoning over guessing.\r\n\r\nYou do NOT have direct kubectl, psql, Test-NetConnection, or any TCP-level tools. You're outside this VNet — see the knowledge base for the architecture.\r\n\r\n## Identities and grants (do NOT try to elevate)\r\n\r\nBoth your system-assigned and user-assigned managed identities have what you need: AKS RBAC Cluster Admin (so `az aks command invoke` works without further consent), Reader + Monitoring Reader + Contributor on the resource group, and PostgreSQL Entra admin. You do NOT have `Microsoft.Authorization/roleAssignments/write`. **Never** attempt `az role assignment create` — it will be denied. If you think you need a role you don't have, the diagnosis is wrong; back up.\r\n\r\n## Always filter telemetry to `zava-api`\r\n\r\nApp Insights and Log Analytics are shared with your own ARM-poll telemetry. Filter every KQL query by `AppRoleName == 'zava-api'` (KQL) or `cloud/roleName == 'zava-api'` (metrics) — unfiltered queries are dominated by agent self-noise.\r\n\r\n## What the Zava alerts mean\r\n\r\n| Alert title | Meaning |\r\n|---|---|\r\n| `postgres-server-stopped` / `postgres-server-down` | PostgreSQL Flexible Server is Stopped or unreachable at the TCP layer. Read `state` from ARM; if Stopped, start it. |\r\n| `postgres-network-blocked` | App pods see `ETIMEDOUT` to PG's private IP. PG is up; something is dropping packets. There are two enforcement surfaces between the app pods and PG (an NSG on the AKS subnet, and Kubernetes NetworkPolicy inside the cluster) — both can produce this symptom. The KB documents which is platform-managed and which is user-controlled. |\r\n| `Zava-products-query-slow` | App Insights `AppRequests` for `/api/products*` (excluding `__probe`) breached the latency threshold. Bottleneck is at PostgreSQL, not pods/CPU/memory. Look at PG's own statistics views (the KB documents the helper for running SQL through the app pod). Never restart pods or scale the cluster for this alert. |\r\n| `Zava-http-5xx-errors` | Composite signal — almost always a downstream effect of one of the conditions above. Check those first before treating it as a separate failure. |\r\n\r\n## Permitted autonomous actions\r\n\r\n- Start / restart / parameter-set on PostgreSQL Flexible Server.\r\n- Delete a NetworkPolicy in `zava-demo` whose egress blocks PG, and delete a matching NSG deny rule on the AKS subnet.\r\n- Restart deployments in `zava-demo`.\r\n- Read-mostly DDL on PostgreSQL: `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, `ANALYZE`, `REINDEX CONCURRENTLY`.\r\n\r\n## Out of scope (require human approval)\r\n\r\n- `DROP`, DML, schema migrations, role/grant changes.\r\n- Cluster scale, node deletion, VNet changes.\r\n- Any IAM modification.\r\n\r\n## Verification\r\n\r\nRe-check the resource you changed, confirm error rate / latency is back to baseline, confirm the alert auto-mitigated.\r\n",
+              "skillContent": "## Zava Incident Runbook\r\n\r\nResource Group: `@@RG@@`. App Insights `cloud_RoleName`: `zava-api`. App k8s namespace: `zava-demo`.\r\n\r\nYou diagnose from telemetry, then remediate within the permitted-action boundary below. Outside that boundary you summarize and stop. When in doubt about an Azure / AKS / PostgreSQL surface you haven't seen before, look it up in Microsoft Learn before guessing.\r\n\r\n## Tools you have\r\n\r\nYou operate with your **own managed identity (Entra)** — no passwords, no app credentials. You work AKS through the Kubernetes control plane (your `kubectl` tools, authenticated by your Entra identity) and the database/resources through the Azure control plane (`az`). Important nuance: your sandbox's egress is **HTTP(S)-proxy-brokered**, so it can reach allow-listed HTTPS endpoints (ARM, Entra, Azure Monitor, Microsoft Learn) but **cannot open raw TCP to private VNet IPs** — so PostgreSQL SQL runs from an in-cluster app pod (a real VNet NIC) via `kubectl exec`, never a direct socket from your sandbox.\r\n\r\n- **kubectl (read + write + help)** — `RunKubectlReadCommand` / `RunKubectlWriteCommand` / `RunKubectlCommandHelp`. First-class kubectl against the AKS API with your Entra identity (you hold AKS RBAC Cluster Admin). Use these directly for pods, logs, events, deployments, and NetworkPolicies. Do NOT hand-wrap kubectl inside `az aks command invoke`.\r\n- **Terminal in your sandbox** — `RunInTerminal` runs shell commands (`python3`, `node`, scripts) inside your workspace sandbox. Important: the sandbox's egress is HTTP(S)-proxy-brokered — it can reach allow-listed HTTPS endpoints but **cannot open raw TCP to private VNet IPs** (e.g. PostgreSQL:5432 — verified refused). Use it for compute/scripting, not for direct database or private-service connections.\r\n- **PostgreSQL SQL** — your sandbox can't open a raw socket to the private database, so run SQL (reads `pg_stat_*`, and read-mostly DDL like `CREATE INDEX CONCURRENTLY` / `ANALYZE`) through the in-cluster helper, which executes from an app pod (a real VNet NIC): `kubectl exec -n zava-demo deploy/zava-api -- node bin/run-sql.js \"<SQL>\"` (the helper reuses the app pod's PG Entra identity).\r\n- **`az` CLI (read + write)** — `RunAzCliReadCommands` / `RunAzCliWriteCommands`. Your control-plane interface: PostgreSQL start/stop/parameter-set, NSG rules, resource state, Azure Monitor.\r\n- **Memory search** — past investigations and the architecture knowledge base.\r\n- **Microsoft Learn search/fetch** — for Azure / AKS / PostgreSQL Flexible Server / KQL surfaces you're unsure about. Prefer documenting your reasoning over guessing.\r\n\r\n## Identities and grants (do NOT try to elevate)\r\n\r\nBoth your system-assigned and user-assigned managed identities have what you need: AKS RBAC Cluster Admin (so kubectl works without further consent), Reader + Monitoring Reader + Contributor on the resource group, and PostgreSQL Entra admin (the app pod's identity, used by `bin/run-sql.js`, is also a PG Entra admin). You do NOT have `Microsoft.Authorization/roleAssignments/write`. **Never** attempt `az role assignment create` — it will be denied. If you think you need a role you don't have, the diagnosis is wrong; back up.\r\n\r\n## Always filter telemetry to `zava-api`\r\n\r\nApp Insights and Log Analytics are shared with your own ARM-poll telemetry. Filter every KQL query by `AppRoleName == 'zava-api'` (KQL) or `cloud/roleName == 'zava-api'` (metrics) — unfiltered queries are dominated by agent self-noise.\r\n\r\n## What the Zava alerts mean\r\n\r\n| Alert title | Meaning |\r\n|---|---|\r\n| `postgres-server-stopped` / `postgres-server-down` | PostgreSQL Flexible Server is Stopped or unreachable at the TCP layer. Read `state` from ARM; if Stopped, start it. |\r\n| `postgres-network-blocked` | App pods see `ETIMEDOUT` to PG's private IP. PG is up; something is dropping packets. There are two enforcement surfaces between the app pods and PG (an NSG on the AKS subnet, and Kubernetes NetworkPolicy inside the cluster) — both can produce this symptom. The KB documents which is platform-managed and which is user-controlled. |\r\n| `Zava-products-query-slow` | App Insights `AppRequests` for `/api/products*` (excluding `__probe`) breached the latency threshold. Bottleneck is at PostgreSQL, not pods/CPU/memory. Inspect PG's statistics views (`pg_stat_statements`, `pg_stat_user_indexes`, `pg_stat_activity`, `EXPLAIN`) by running SQL through the in-cluster helper with kubectl: `kubectl exec -n zava-demo deploy/zava-api -- node bin/run-sql.js \"<SQL>\"`. Never restart pods or scale the cluster for this alert. |\r\n| `Zava-category-latency-metric` | The app's own custom METRIC (`zava.products.category.query.duration_ms` in `AppMetrics`) for a non-probe category breached the latency threshold. Treat this as a first-class corroborating signal for the SAME slow-query incident as `Zava-products-query-slow` (the `AppRequests` log signal) and the `AppDependencies` PostgreSQL-call latency (the trace signal) — logs + metrics + traces agreeing points at the database query, not pods/CPU/memory. Diagnose at PG exactly as for `Zava-products-query-slow`. |\r\n| `Zava-db-cpu-saturation` | PostgreSQL server CPU is saturated (platform metric). On its own it can be organic load, but co-firing with the slow-query signals above corroborates a database-side bottleneck (e.g. heavy scans). Inspect PG activity and statistics views before considering any compute change; do not scale the cluster for this alert. |\r\n| `Zava-http-5xx-errors` | Composite signal. First rule out the conditions above — a 5xx spike is usually a downstream effect of a DB outage, network partition, or slow-query bottleneck. If none of those correlate, treat it as a possible **bad deploy**: check recent rollout history (`kubectl rollout history deployment/zava-api -n zava-demo`) and recent deployment changes / `KubeEvents` (`ScalingReplicaSet`). A 5xx regression whose onset lines up with a recent rollout is a deployment regression — roll back to the previous good revision (see permitted actions). |\r\n\r\n## Permitted autonomous actions\r\n\r\n- Start / restart / parameter-set on PostgreSQL Flexible Server.\r\n- Delete a NetworkPolicy in `zava-demo` whose egress blocks PG, and delete a matching NSG deny rule on the AKS subnet.\r\n- Restart deployments in `zava-demo`.\r\n- Roll back a deployment in `zava-demo` to its previous revision (`kubectl rollout undo`) when a 5xx regression correlates with a recent rollout.\r\n- Read-mostly DDL on PostgreSQL: `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, `ANALYZE`, `REINDEX CONCURRENTLY`.\r\n\r\n## Out of scope (require human approval)\r\n\r\n- `DROP`, DML, schema migrations, role/grant changes.\r\n- Cluster scale, node deletion, VNet changes.\r\n- Any IAM modification.\r\n\r\n## Verification\r\n\r\nRe-check the resource you changed, confirm error rate / latency is back to baseline, confirm the alert auto-mitigated.\r\n",
               "additionalFiles": [],
               "sourcePluginInstallation": null
             },
@@ -1518,6 +1847,7 @@
               "tools": [
                 "RunAzCliReadCommands",
                 "RunAzCliWriteCommands",
+                "RunKubectlReadCommand",
                 "SearchMemory",
                 "ExecutePythonCode",
                 "microsoft-learn_microsoft_code_sample_search",
@@ -1605,6 +1935,22 @@
                 }
               },
               "properties": {
+                "vnetConfiguration": {
+                  "subnetResourceId": "[parameters('agentSubnetId')]"
+                },
+                "sandboxConfiguration": {
+                  "egress": {
+                    "mode": "AzureVNet",
+                    "vnetConfiguration": {
+                      "usePrivateDnsResolution": true
+                    },
+                    "allowHttpMcpServerNetworkAccess": true,
+                    "allowedCodeRepositories": [],
+                    "allowedRegistries": [],
+                    "allowedHosts": []
+                  },
+                  "packages": []
+                },
                 "knowledgeGraphConfiguration": {
                   "managedResources": [
                     "[parameters('managedResourceGroupId')]"
@@ -1846,7 +2192,8 @@
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'aks')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'identity')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'monitoring')]",
-        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'vnet')]"
       ]
     },
     {
@@ -1876,8 +2223,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "2351920676602393766"
+              "version": "0.43.1.21952",
+              "templateHash": "1813198627844114663"
             }
           },
           "parameters": {
@@ -1959,8 +2306,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "2351920676602393766"
+              "version": "0.43.1.21952",
+              "templateHash": "1813198627844114663"
             }
           },
           "parameters": {
@@ -2043,8 +2390,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "2351920676602393766"
+              "version": "0.43.1.21952",
+              "templateHash": "1813198627844114663"
             }
           },
           "parameters": {

--- a/labs/zava-aks-postgres/infra/modules/monitoring.bicep
+++ b/labs/zava-aks-postgres/infra/modules/monitoring.bicep
@@ -404,6 +404,118 @@ resource alertProductsSlow 'Microsoft.Insights/scheduledQueryRules@2023-03-15-pr
   }
 }
 
+// Alert: Category-query custom METRIC latency (scheduled-query alert against AppMetrics).
+//
+// This is the first-class *metric* signal for the slow-query incident. The app
+// emits an OTel histogram `zava.products.category.query.duration_ms` (see
+// src/api/logging/logger.js + routes/products.js) which the @azure/monitor-
+// opentelemetry exporter ships to this workspace-based App Insights component's
+// AppMetrics table (Name = the instrument name; the per-request `category`
+// attribute lands in the dynamic Properties column).
+//
+// Why a scheduled-query (KQL-on-AppMetrics) rule and NOT a Microsoft.Insights/
+// metricAlert on a custom metric namespace: for workspace-based App Insights,
+// OTel custom metrics are reliably queryable in AppMetrics but are NOT reliably
+// exposed as a splittable custom metric namespace with the `category` dimension
+// in the metricAlert plane. Reading AppMetrics keeps the dimension and matches
+// the proven alertProductsSlow pattern. This still demonstrates a metric SIGNAL
+// the app itself defines and emits — making "metrics as a first-class signal"
+// demoable — and corroborates the AppRequests log alert + AppDependencies pg-call
+// latency for the same incident.
+//
+// Threshold logic mirrors alertProductsSlow: weighted mean per non-probe
+// category over 5 min, fire when ANY category mean exceeds 30 ms (healthy
+// baseline ~3 ms). `__probe` is excluded so the 1 Hz self-probe baseline alone
+// never fires it. AppMetrics aggregates each export interval into Sum/ItemCount,
+// so the true mean is sum(Sum)/sum(ItemCount).
+resource alertCategoryLatencyMetric 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
+  name: 'Zava-category-latency-metric'
+  location: location
+  properties: {
+    severity: 2
+    enabled: true
+    evaluationFrequency: 'PT1M'
+    windowSize: 'PT5M'
+    scopes: [law.id]
+    criteria: {
+      allOf: [
+        {
+          query: '''AppMetrics
+| where AppRoleName == 'zava-api'
+| where Name == 'zava.products.category.query.duration_ms'
+| extend Category = tostring(Properties['category'])
+| where Category != '__probe'
+| summarize AvgDurationMs = sum(Sum) / sum(ItemCount) by Category
+| where AvgDurationMs > 30'''
+          timeAggregation: 'Count'
+          operator: 'GreaterThan'
+          threshold: 0
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    actions: {
+      actionGroups: [actionGroup.id]
+    }
+    autoMitigate: true
+    // Symptom-only by design — do NOT name a suspected index or table here.
+    description: 'Zava Demo: the zava.products.category.query.duration_ms custom metric averaged above 30ms for at least one category over 5 minutes (healthy baseline ~3ms).'
+  }
+}
+
+// Alert: PostgreSQL CPU saturation (platform METRIC alert).
+//
+// Consumes a metric PG Flexible Server already emits (the `AllMetrics`
+// diagnostic category is enabled on pgDiagnostics above), so no app change or
+// break script is needed — it is an additive, proactive/corroborating signal.
+// Scoped directly to the PG server resource with the platform metric namespace,
+// so it is a TRUE Microsoft.Insights/metricAlert (unlike the custom-metric rule
+// above, which has to read AppMetrics). Under the missing-index load run the
+// 120k-row sequential scans drive PG CPU up, so this may co-fire with the
+// slow-query signals and corroborate that the bottleneck is at the database.
+//
+// Named with the `Zava-` prefix (and deliberately WITHOUT the substring
+// `postgres`) so it routes to `zava-app-response`, alongside the other
+// slow-query signals — see the non-overlapping titleContains split in
+// sre-agent.bicep.
+resource alertPgCpuSaturation 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'Zava-db-cpu-saturation'
+  location: 'global'
+  properties: {
+    severity: 3
+    enabled: true
+    scopes: [pgServer.id]
+    evaluationFrequency: 'PT1M'
+    windowSize: 'PT5M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'pgCpu'
+          metricName: 'cpu_percent'
+          metricNamespace: 'Microsoft.DBforPostgreSQL/flexibleServers'
+          operator: 'GreaterThan'
+          // 80% average over 5 min: the GeneralPurpose D2ds_v5 SKU sits well
+          // below this at the 1 Hz self-probe baseline, so a healthy demo does
+          // not fire, but sustained un-indexed seq scans push it over.
+          threshold: 80
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      { actionGroupId: actionGroup.id }
+    ]
+    autoMitigate: true
+    // Symptom-only by design — do NOT add cause/remediation/scenario hints here.
+    description: 'Zava Demo: PostgreSQL server CPU averaged above 80% over 5 minutes.'
+  }
+}
+
 // Alert: PostgreSQL server stopped (Activity Log — detects az postgres flexible-server stop)
 // Named without "Zava-" prefix so the "postgres" response plan filter matches exclusively
 resource alertPgStopped 'Microsoft.Insights/activityLogAlerts@2023-01-01-preview' = {

--- a/labs/zava-aks-postgres/infra/modules/sre-agent.bicep
+++ b/labs/zava-aks-postgres/infra/modules/sre-agent.bicep
@@ -26,6 +26,9 @@ param managedResourceGroupId string
 @description('AKS cluster name — used to grant system identity K8s-level RBAC')
 param aksClusterName string
 
+@description('Resource ID of the VNet-injection subnet (delegated to Microsoft.App/environments). The agent sandbox runs here with egress forced through the Azure Firewall.')
+param agentSubnetId string
+
 @description('AI model provider for the agent (Anthropic enables web search; not in EU Data Boundary)')
 @allowed([
   'Anthropic'
@@ -60,6 +63,37 @@ resource sreAgent 'Microsoft.App/agents@2025-05-01-preview' = {
     }
   }
   properties: {
+    // VNet injection: the agent's sandbox (where its CLI tools run) is placed in
+    // the delegated agent subnet, with all egress forced through the Azure Firewall.
+    // The agent works the cluster with native, first-class kubectl tools
+    // authenticated by its own managed identity, runs PostgreSQL SQL through an
+    // in-cluster helper, and uses az / ARM for control-plane actions and Azure
+    // Monitor — all permitted by the firewall allow-list. No public reachability
+    // to the AKS API server or PostgreSQL is required.
+    vnetConfiguration: {
+      subnetResourceId: agentSubnetId
+    }
+    sandboxConfiguration: {
+      egress: {
+        mode: 'AzureVNet'
+        vnetConfiguration: {
+          usePrivateDnsResolution: true
+        }
+        // Remote HTTP MCP servers (the microsoft-learn connector below) are
+        // brokered by the platform rather than the customer VNet — required for
+        // the agent's Microsoft Learn lookups to work behind the firewall.
+        allowHttpMcpServerNetworkAccess: true
+        allowedCodeRepositories: []
+        // Maximum lockdown: nothing extra is allow-listed. Note the sandbox egress is
+        // HTTP(S)-proxy-brokered — it reaches allow-listed HTTPS endpoints (ARM,
+        // Entra, Azure Monitor, Microsoft Learn) but CANNOT open raw TCP to private VNet
+        // IPs (e.g. PostgreSQL:5432, verified). Private DB access therefore runs from an
+        // in-cluster pod (a real VNet NIC) via `kubectl exec`, not from the agent sandbox.
+        allowedRegistries: []
+        allowedHosts: []
+      }
+      packages: []
+    }
     knowledgeGraphConfiguration: {
       managedResources: [
         managedResourceGroupId
@@ -235,6 +269,10 @@ var dbIncidentSkill = {
   tools: [
     'RunAzCliReadCommands'
     'RunAzCliWriteCommands'
+    'RunKubectlReadCommand'
+    'RunKubectlWriteCommand'
+    'RunKubectlCommandHelp'
+    'RunInTerminal'
     'SearchMemory'
     'microsoft-learn_microsoft_code_sample_search'
     'microsoft-learn_microsoft_docs_fetch'
@@ -249,15 +287,18 @@ You diagnose from telemetry, then remediate within the permitted-action boundary
 
 ## Tools you have
 
-- **`az` CLI (read + write)** — your only Azure interface. For in-cluster operations (kubectl, exec, SQL through the app pod), the path is `az aks command invoke`.
+You operate with your **own managed identity (Entra)** — no passwords, no app credentials. You work AKS through the Kubernetes control plane (your `kubectl` tools, authenticated by your Entra identity) and the database/resources through the Azure control plane (`az`). Important nuance: your sandbox's egress is **HTTP(S)-proxy-brokered**, so it can reach allow-listed HTTPS endpoints (ARM, Entra, Azure Monitor, Microsoft Learn) but **cannot open raw TCP to private VNet IPs** — so PostgreSQL SQL runs from an in-cluster app pod (a real VNet NIC) via `kubectl exec`, never a direct socket from your sandbox.
+
+- **kubectl (read + write + help)** — `RunKubectlReadCommand` / `RunKubectlWriteCommand` / `RunKubectlCommandHelp`. First-class kubectl against the AKS API with your Entra identity (you hold AKS RBAC Cluster Admin). Use these directly for pods, logs, events, deployments, and NetworkPolicies. Do NOT hand-wrap kubectl inside `az aks command invoke`.
+- **Terminal in your sandbox** — `RunInTerminal` runs shell commands (`python3`, `node`, scripts) inside your workspace sandbox. Important: the sandbox's egress is HTTP(S)-proxy-brokered — it can reach allow-listed HTTPS endpoints but **cannot open raw TCP to private VNet IPs** (e.g. PostgreSQL:5432 — verified refused). Use it for compute/scripting, not for direct database or private-service connections.
+- **PostgreSQL SQL** — your sandbox can't open a raw socket to the private database, so run SQL (reads `pg_stat_*`, and read-mostly DDL like `CREATE INDEX CONCURRENTLY` / `ANALYZE`) through the in-cluster helper, which executes from an app pod (a real VNet NIC): `kubectl exec -n zava-demo deploy/zava-api -- node bin/run-sql.js "<SQL>"` (the helper reuses the app pod's PG Entra identity).
+- **`az` CLI (read + write)** — `RunAzCliReadCommands` / `RunAzCliWriteCommands`. Your control-plane interface: PostgreSQL start/stop/parameter-set, NSG rules, resource state, Azure Monitor.
 - **Memory search** — past investigations and the architecture knowledge base.
 - **Microsoft Learn search/fetch** — for Azure / AKS / PostgreSQL Flexible Server / KQL surfaces you're unsure about. Prefer documenting your reasoning over guessing.
 
-You do NOT have direct kubectl, psql, Test-NetConnection, or any TCP-level tools. You're outside this VNet — see the knowledge base for the architecture.
-
 ## Identities and grants (do NOT try to elevate)
 
-Both your system-assigned and user-assigned managed identities have what you need: AKS RBAC Cluster Admin (so `az aks command invoke` works without further consent), Reader + Monitoring Reader + Contributor on the resource group, and PostgreSQL Entra admin. You do NOT have `Microsoft.Authorization/roleAssignments/write`. **Never** attempt `az role assignment create` — it will be denied. If you think you need a role you don't have, the diagnosis is wrong; back up.
+Both your system-assigned and user-assigned managed identities have what you need: AKS RBAC Cluster Admin (so kubectl works without further consent), Reader + Monitoring Reader + Contributor on the resource group, and PostgreSQL Entra admin (the app pod's identity, used by `bin/run-sql.js`, is also a PG Entra admin). You do NOT have `Microsoft.Authorization/roleAssignments/write`. **Never** attempt `az role assignment create` — it will be denied. If you think you need a role you don't have, the diagnosis is wrong; back up.
 
 ## Always filter telemetry to `zava-api`
 
@@ -269,14 +310,17 @@ App Insights and Log Analytics are shared with your own ARM-poll telemetry. Filt
 |---|---|
 | `postgres-server-stopped` / `postgres-server-down` | PostgreSQL Flexible Server is Stopped or unreachable at the TCP layer. Read `state` from ARM; if Stopped, start it. |
 | `postgres-network-blocked` | App pods see `ETIMEDOUT` to PG's private IP. PG is up; something is dropping packets. There are two enforcement surfaces between the app pods and PG (an NSG on the AKS subnet, and Kubernetes NetworkPolicy inside the cluster) — both can produce this symptom. The KB documents which is platform-managed and which is user-controlled. |
-| `Zava-products-query-slow` | App Insights `AppRequests` for `/api/products*` (excluding `__probe`) breached the latency threshold. Bottleneck is at PostgreSQL, not pods/CPU/memory. Look at PG's own statistics views (the KB documents the helper for running SQL through the app pod). Never restart pods or scale the cluster for this alert. |
-| `Zava-http-5xx-errors` | Composite signal — almost always a downstream effect of one of the conditions above. Check those first before treating it as a separate failure. |
+| `Zava-products-query-slow` | App Insights `AppRequests` for `/api/products*` (excluding `__probe`) breached the latency threshold. Bottleneck is at PostgreSQL, not pods/CPU/memory. Inspect PG's statistics views (`pg_stat_statements`, `pg_stat_user_indexes`, `pg_stat_activity`, `EXPLAIN`) by running SQL through the in-cluster helper with kubectl: `kubectl exec -n zava-demo deploy/zava-api -- node bin/run-sql.js "<SQL>"`. Never restart pods or scale the cluster for this alert. |
+| `Zava-category-latency-metric` | The app's own custom METRIC (`zava.products.category.query.duration_ms` in `AppMetrics`) for a non-probe category breached the latency threshold. Treat this as a first-class corroborating signal for the SAME slow-query incident as `Zava-products-query-slow` (the `AppRequests` log signal) and the `AppDependencies` PostgreSQL-call latency (the trace signal) — logs + metrics + traces agreeing points at the database query, not pods/CPU/memory. Diagnose at PG exactly as for `Zava-products-query-slow`. |
+| `Zava-db-cpu-saturation` | PostgreSQL server CPU is saturated (platform metric). On its own it can be organic load, but co-firing with the slow-query signals above corroborates a database-side bottleneck (e.g. heavy scans). Inspect PG activity and statistics views before considering any compute change; do not scale the cluster for this alert. |
+| `Zava-http-5xx-errors` | Composite signal. First rule out the conditions above — a 5xx spike is usually a downstream effect of a DB outage, network partition, or slow-query bottleneck. If none of those correlate, treat it as a possible **bad deploy**: check recent rollout history (`kubectl rollout history deployment/zava-api -n zava-demo`) and recent deployment changes / `KubeEvents` (`ScalingReplicaSet`). A 5xx regression whose onset lines up with a recent rollout is a deployment regression — roll back to the previous good revision (see permitted actions). |
 
 ## Permitted autonomous actions
 
 - Start / restart / parameter-set on PostgreSQL Flexible Server.
 - Delete a NetworkPolicy in `zava-demo` whose egress blocks PG, and delete a matching NSG deny rule on the AKS subnet.
 - Restart deployments in `zava-demo`.
+- Roll back a deployment in `zava-demo` to its previous revision (`kubectl rollout undo`) when a 5xx regression correlates with a recent rollout.
 - Read-mostly DDL on PostgreSQL: `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, `ANALYZE`, `REINDEX CONCURRENTLY`.
 
 ## Out of scope (require human approval)
@@ -298,6 +342,7 @@ var proactiveHealthSkill = {
   tools: [
     'RunAzCliReadCommands'
     'RunAzCliWriteCommands'
+    'RunKubectlReadCommand'
     'SearchMemory'
     'ExecutePythonCode'
     'microsoft-learn_microsoft_code_sample_search'

--- a/labs/zava-aks-postgres/infra/modules/vnet.bicep
+++ b/labs/zava-aks-postgres/infra/modules/vnet.bicep
@@ -7,6 +7,10 @@ param uniqueSuffix string
 var vnetName = 'vnet-Zava-${uniqueSuffix}'
 var nsgName = 'nsg-aks-${uniqueSuffix}'
 
+// First usable address in AzureFirewallSubnet (Azure reserves .0-.3 of the subnet).
+// Kept in sync with the AzureFirewallSubnet prefix below.
+var firewallPrivateIp = '10.3.1.4'
+
 resource nsg 'Microsoft.Network/networkSecurityGroups@2024-01-01' = {
   name: nsgName
   location: location
@@ -29,6 +33,42 @@ resource nsg 'Microsoft.Network/networkSecurityGroups@2024-01-01' = {
           sourcePortRange: '*'
           destinationAddressPrefix: '*'
           destinationPortRange: '*'
+        }
+      }
+    ]
+  }
+}
+
+// Public IP for the Azure Firewall frontend (the only public ingress in the VNet).
+resource firewallPip 'Microsoft.Network/publicIPAddresses@2024-05-01' = {
+  name: 'afw-pip-Zava-${uniqueSuffix}'
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+}
+
+// Forced tunneling for the SRE Agent subnet only: all egress (0.0.0.0/0) is
+// routed to the Azure Firewall. Intra-VNet traffic (10.0.0.0/8) keeps the more
+// specific system route, so the agent still reaches AKS / PG privately. The AKS
+// and DB subnets are deliberately NOT routed through the firewall — AKS manages
+// its own egress and the demo's break/fix scenarios run against the open NSG.
+resource agentRouteTable 'Microsoft.Network/routeTables@2024-05-01' = {
+  name: 'rt-agent-${uniqueSuffix}'
+  location: location
+  properties: {
+    disableBgpRoutePropagation: true
+    routes: [
+      {
+        name: 'default-to-azure-firewall'
+        properties: {
+          addressPrefix: '0.0.0.0/0'
+          nextHopType: 'VirtualAppliance'
+          nextHopIpAddress: firewallPrivateIp
         }
       }
     ]
@@ -67,6 +107,31 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
           ]
         }
       }
+      {
+        // SRE Agent workload subnet — delegated to Microsoft.App/environments so
+        // the agent's sandbox is injected here, with all egress forced through
+        // the Azure Firewall (route table above). Minimum size is /27.
+        name: 'agent-subnet'
+        properties: {
+          addressPrefix: '10.3.0.0/27'
+          routeTable: { id: agentRouteTable.id }
+          delegations: [
+            {
+              name: 'agent-delegation'
+              properties: {
+                serviceName: 'Microsoft.App/environments'
+              }
+            }
+          ]
+        }
+      }
+      {
+        // Required name for the Azure Firewall. Minimum size is /26.
+        name: 'AzureFirewallSubnet'
+        properties: {
+          addressPrefix: '10.3.1.0/26'
+        }
+      }
     ]
   }
 }
@@ -86,9 +151,143 @@ resource privateDnsVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
   }
 }
 
+// Firewall policy: default-deny egress with a precise allow-list. DNS proxy is on
+// so the firewall resolves FQDNs for the application rules. Threat intel denies
+// known-bad destinations.
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
+  name: 'afw-policy-Zava-${uniqueSuffix}'
+  location: location
+  properties: {
+    sku: { tier: 'Standard' }
+    dnsSettings: {
+      enableProxy: true
+    }
+    threatIntelMode: 'Deny'
+  }
+}
+
+// Allow-list = exactly what the VNet-injected SRE Agent needs to operate:
+// DNS, ARM / Entra / Microsoft Graph, Azure Monitor (App Insights + Log
+// Analytics queries), and Microsoft Learn (the agent's learn MCP / docs tools).
+// `az aks command invoke` and all azcli operations ride ARM, so they work
+// through these rules without exposing the cluster API server publicly.
+// AzureCloud is deliberately NOT used (it covers ~65k prefixes including
+// third-party SaaS); precise service tags are used instead.
+resource ruleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-05-01' = {
+  parent: firewallPolicy
+  name: 'DefaultNetworkRuleCollectionGroup'
+  properties: {
+    priority: 200
+    ruleCollections: [
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        name: 'allow-essential-dns'
+        priority: 100
+        action: { type: 'Allow' }
+        rules: [
+          {
+            ruleType: 'NetworkRule'
+            name: 'allow-azure-dns'
+            description: 'DNS resolution via Azure DNS (required for the firewall DNS proxy)'
+            ipProtocols: ['UDP', 'TCP']
+            sourceAddresses: ['10.3.0.0/27']
+            destinationAddresses: ['168.63.129.16']
+            destinationPorts: ['53']
+          }
+        ]
+      }
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        name: 'allow-azure-service-tags'
+        priority: 105
+        action: { type: 'Allow' }
+        rules: [
+          {
+            ruleType: 'NetworkRule'
+            name: 'allow-azure-services-l4'
+            description: 'L4 access to Azure services via precise service tags (NOT AzureCloud)'
+            ipProtocols: ['TCP']
+            sourceAddresses: ['10.3.0.0/27']
+            destinationAddresses: [
+              'AzureResourceManager'
+              'AzureActiveDirectory'
+              'AzureMonitor'
+            ]
+            destinationPorts: ['443']
+          }
+        ]
+      }
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        name: 'allow-agent-azure-services'
+        priority: 150
+        action: { type: 'Allow' }
+        rules: [
+          {
+            ruleType: 'ApplicationRule'
+            name: 'allow-arm-aad-graph'
+            description: 'FQDN access to ARM, Entra ID, and Microsoft Graph'
+            sourceAddresses: ['10.3.0.0/27']
+            protocols: [{ protocolType: 'Https', port: 443 }]
+            targetFqdns: [
+              'management.azure.com'
+              'login.microsoftonline.com'
+              'graph.microsoft.com'
+            ]
+          }
+        ]
+      }
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        name: 'allow-microsoft-learn'
+        priority: 200
+        action: { type: 'Allow' }
+        rules: [
+          {
+            ruleType: 'ApplicationRule'
+            name: 'allow-learn-microsoft-com'
+            description: 'Microsoft Learn docs + MCP (the agent looks up Azure/AKS/PostgreSQL guidance here)'
+            sourceAddresses: ['10.3.0.0/27']
+            protocols: [{ protocolType: 'Https', port: 443 }]
+            targetFqdns: [
+              'learn.microsoft.com'
+              '*.learn.microsoft.com'
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+
+resource firewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
+  name: 'afw-Zava-${uniqueSuffix}'
+  location: location
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Standard'
+    }
+    firewallPolicy: { id: firewallPolicy.id }
+    ipConfigurations: [
+      {
+        name: 'fw-ipconfig'
+        properties: {
+          subnet: { id: vnet.properties.subnets[3].id }
+          publicIPAddress: { id: firewallPip.id }
+        }
+      }
+    ]
+  }
+  dependsOn: [
+    ruleCollectionGroup
+  ]
+}
+
 output vnetName string = vnet.name
 output vnetId string = vnet.id
 output aksSubnetId string = vnet.properties.subnets[0].id
 output dbSubnetId string = vnet.properties.subnets[1].id
+output agentSubnetId string = vnet.properties.subnets[2].id
 output nsgName string = nsg.name
 output privateDnsZoneId string = privateDnsZone.id

--- a/labs/zava-aks-postgres/src/api/logging/logger.js
+++ b/labs/zava-aks-postgres/src/api/logging/logger.js
@@ -9,10 +9,18 @@ const { useAzureMonitor } = require('@azure/monitor-opentelemetry');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
 const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { logs } = require('@opentelemetry/api-logs');
+const { metrics } = require('@opentelemetry/api');
 
 const aiConnStr = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
 
+// Mirror alertProductsSlow's 30 ms latency threshold so the custom metric and
+// the log-based alert tell the same story (healthy category query ~3 ms; a
+// dropped index pushes the 120k-row scan well past 30 ms).
+const SLOW_QUERY_THRESHOLD_MS = 30;
+
 let logger = null;
+let categoryQueryDuration = null;
+let slowQueryCount = null;
 
 if (aiConnStr && aiConnStr.startsWith('InstrumentationKey=')) {
   useAzureMonitor({
@@ -29,6 +37,37 @@ if (aiConnStr && aiConnStr.startsWith('InstrumentationKey=')) {
   });
 
   logger = logs.getLogger('zava-api');
+
+  // Custom OTel app metrics. `useAzureMonitor` registers a global MeterProvider
+  // whose PeriodicExportingMetricReader ships to the Azure Monitor breeze
+  // endpoint — so instruments created off `metrics.getMeter(...)` land in this
+  // workspace-based App Insights component's `AppMetrics` table (a.k.a.
+  // `customMetrics`), Name = the instrument name. This is what makes metrics a
+  // first-class telemetry signal alongside AppTraces (logs) and
+  // AppRequests/AppDependencies (traces) for the SAME slow-query incident.
+  const meter = metrics.getMeter('zava-api');
+  categoryQueryDuration = meter.createHistogram('zava.products.category.query.duration_ms', {
+    description: 'Server-side duration of the products-by-category DB query',
+    unit: 'ms',
+  });
+  slowQueryCount = meter.createCounter('zava.products.slow_query.count', {
+    description: 'Count of category queries whose DB duration exceeded the slow-query threshold',
+  });
+}
+
+// Record one category-query duration sample. The only attribute is `category`,
+// whose values are the fixed seed categories plus the synthetic `__probe` — a
+// bounded set. Do NOT add per-request attributes (id, sku, limit, user): those
+// would explode metric series cardinality. The histogram includes `__probe`
+// (the 1 Hz self-probe) so the metric stream has continuous data and climbs
+// under a missing-index regression; the alert layer excludes `__probe` to mirror
+// alertProductsSlow, so synthetic baseline traffic alone never fires it.
+function recordCategoryQueryDuration(category, durationMs) {
+  if (!categoryQueryDuration) return;
+  categoryQueryDuration.record(durationMs, { category });
+  if (durationMs > SLOW_QUERY_THRESHOLD_MS && category !== '__probe') {
+    slowQueryCount.add(1, { category });
+  }
 }
 
 function log(level, message, properties = {}) {
@@ -72,4 +111,4 @@ function log(level, message, properties = {}) {
   }
 }
 
-module.exports = { log };
+module.exports = { log, recordCategoryQueryDuration };

--- a/labs/zava-aks-postgres/src/api/routes/products.js
+++ b/labs/zava-aks-postgres/src/api/routes/products.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const pool = require('../db/client');
-const { log } = require('../logging/logger');
+const { log, recordCategoryQueryDuration } = require('../logging/logger');
 const router = express.Router();
 
 router.get('/', async (req, res) => {
@@ -23,7 +23,11 @@ router.get('/category/:category', async (req, res) => {
     const offset = parseInt(req.query.offset) || 0;
     const safeLimit = Math.min(Math.max(limit, 1), 100);
     const safeOffset = Math.max(offset, 0);
+    // Time only the DB query so the custom metric reflects PostgreSQL latency
+    // (index scan vs seq scan), not Express/serialization overhead.
+    const queryStart = Date.now();
     const { rows } = await pool.query('SELECT id, sku, name, price, category, stock_quantity FROM products WHERE category = $1 ORDER BY name LIMIT $2 OFFSET $3', [req.params.category, safeLimit, safeOffset]);
+    recordCategoryQueryDuration(req.params.category, Date.now() - queryStart);
     res.json(rows);
   } catch (err) {
     log('error', 'Failed to fetch products by category', { error: err.message, code: err.code, category: req.params.category });

--- a/labs/zava-aks-postgres/src/api/server.js
+++ b/labs/zava-aks-postgres/src/api/server.js
@@ -32,6 +32,27 @@ app.use((req, res, next) => {
   next();
 });
 
+// Fault-injection toggle (Scenario 4 — Bad Deploy / Rollback). Default OFF.
+// When FAULT_INJECT=500, the product listing route (GET /api/products) returns
+// HTTP 500, simulating a regression shipped by a bad config rollout. The 1 Hz
+// self-probe already hits /api/products, so this produces a steady 5xx spike
+// that the existing Zava-http-5xx-errors metric alert detects — no external
+// load generator needed. The bad "deploy" is applied with `kubectl set env`,
+// which creates a new ReplicaSet revision: that rollout IS the deployment
+// signal the agent correlates the regression against and rolls back with
+// `kubectl rollout undo`.
+// Scoped deliberately to the EXACT /api/products path so liveness (/livez),
+// readiness (/api/health), and the synthetic __probe category path are
+// untouched — pods stay Running and only the app route regresses.
+// Unset/empty => behavior is unchanged (normal deploys are unaffected).
+const FAULT_INJECT = process.env.FAULT_INJECT || '';
+if (FAULT_INJECT === '500') {
+  log('warn', 'FAULT_INJECT=500 active — GET /api/products will return HTTP 500');
+  app.get('/api/products', (req, res) => {
+    res.status(500).json({ error: 'Internal server error' });
+  });
+}
+
 // Routes
 app.use('/api/products', require('./routes/products'));
 app.use('/api/orders', require('./routes/orders'));

--- a/labs/zava-aks-postgres/sre-config/knowledge-base/zava-architecture.md
+++ b/labs/zava-aks-postgres/sre-config/knowledge-base/zava-architecture.md
@@ -4,18 +4,15 @@ A Node.js e-commerce app (`zava-storefront` + `zava-api`) on AKS with Azure Post
 
 ## Environment specifics
 
-### You are outside this VNet
-The agent runtime has no network path to the AKS API server (private cluster, no public FQDN) or PostgreSQL (`publicNetworkAccess: Disabled`, port 5432 unreachable). Direct TCP probes, raw `kubectl --server=...`, `psql`, and `az postgres flexible-server execute` will all fail or be unavailable — that is the network, not a permissions problem.
+### How your sandbox reaches things (and what it can't)
+You operate with your **own managed identity** (no app credentials, no passwords). Your sandbox reaches the network through an **HTTP(S) egress proxy**: it can reach allow-listed HTTPS endpoints (ARM, Entra, Graph, Azure Monitor, Microsoft Learn) but it **cannot open raw TCP to private VNet IPs** (e.g. PostgreSQL:5432). So you work each surface through a control plane or an in-cluster pod, not a direct socket:
 
-Everything goes through `az`:
+1. **ARM control plane** via `az` (`RunAzCliReadCommands` / `RunAzCliWriteCommands`) — PG state/start/stop/parameters, NSG rules, role lookups, identity, AKS metadata, Azure Monitor.
+2. **Kubernetes** via native kubectl tools (`RunKubectlReadCommand` / `RunKubectlWriteCommand` / `RunKubectlCommandHelp`) — first-class kubectl authenticated by your Entra identity (AKS RBAC Cluster Admin). Use them directly for pods, logs, events, deployments, NetworkPolicies.
+3. **Terminal** via `RunInTerminal` — `python3`/`node`/scripts inside your sandbox; HTTP(S) egress only (no raw TCP to private IPs). Use it for compute, not for DB or private-service sockets.
+4. **PostgreSQL SQL** — because your sandbox can't open a socket to the private DB, run SQL (reads `pg_stat_*`, and read-mostly DDL like `CREATE INDEX CONCURRENTLY` / `ANALYZE`) through the in-cluster helper, which executes from an app pod (a real VNet NIC): `kubectl exec -n zava-demo deploy/zava-api -- node bin/run-sql.js "<SQL>"` (reuses the app pod's PG Entra identity).
 
-1. **ARM control plane** for everything ARM exposes (PG state, NSG rules, role lookups, identity, AKS metadata).
-2. **`az aks command invoke`** for in-cluster operations. Pass kubectl args as the `--command` payload; the proxy runs them inside the cluster network. This is your only path to the cluster's API server.
-3. **`bin/run-sql.js` exec'd through `az aks command invoke`** — the only path to PostgreSQL. Helper baked into the `zava-api` container, single SQL statement as its only argv, runs under the pod's workload identity (`DefaultAzureCredential` + `ossrdbms-aad`), prints `JSON.stringify(rows || command)`. The command shape is:
-   ```
-   az aks command invoke -g <rg> -n <aks> --command \
-     "kubectl exec -n zava-demo deploy/zava-api -- node bin/run-sql.js \"<SQL>\""
-   ```
+Note: do **not** rely on database tools that open their PostgreSQL connection from outside the workload VNet -- they can't reach this private server, and the resulting timeout can be misread as "stopped/network-blocked". Run SQL through the in-cluster helper instead.
 
 ### Identities and authorization (already granted — do not try to elevate)
 Both SRE Agent identities (system-assigned + UMI `id-sre-agent-*`) hold:
@@ -33,7 +30,7 @@ Namespace `zava-demo`. Deployments `zava-api`, `zava-storefront`. App Insights `
 ### NSG rules on the PG delegated subnet are platform-managed
 Azure Database for PostgreSQL Flexible Server with private access lives in a *delegated* subnet whose routing/policy is managed by the platform ([subnet delegation overview](https://learn.microsoft.com/azure/virtual-network/subnet-delegation-overview), [PG private networking](https://learn.microsoft.com/azure/postgresql/network/concepts-networking-private)). A user-added NSG deny rule covering port 5432 looks like the smoking gun in configuration but is **not** necessarily the active enforcement point.
 
-This AKS cluster has `networkPolicy: 'azure'` enabled, so **Kubernetes NetworkPolicy** is also an enforcement layer for pod-to-PG traffic — verify both surfaces (`az network nsg rule list` and `az aks command invoke … kubectl get networkpolicy -A -o yaml`) before deciding which control is actually carrying the traffic.
+This AKS cluster has `networkPolicy: 'azure'` enabled, so **Kubernetes NetworkPolicy** is also an enforcement layer for pod-to-PG traffic — verify both surfaces (`az network nsg rule list` and `RunKubectlReadCommand` with `kubectl get networkpolicy -A -o yaml`) before deciding which control is actually carrying the traffic.
 
 ### App Insights workspace is shared with the SRE Agent itself
 The agent's own ARM-poll telemetry lands in the same workspace with empty `cloud_RoleName` and 100–2000ms durations. **Always filter by `AppRoleName == 'zava-api'`** (KQL) or `cloud/roleName == 'zava-api'` (metrics) when investigating Zava — unfiltered queries are dominated by agent self-noise.
@@ -45,4 +42,13 @@ The agent's own ARM-poll telemetry lands in the same workspace with empty `cloud
 Both services run an in-process probe loop (`PROBE_INTERVAL_MS=1000`) hitting `/api/health`, `/api/products`, `/api/products/category/__probe`, and `/livez`. ~60 req/min/pod is synthetic baseline, not load. The slow-query alert KQL excludes the `__probe` path so synthetic traffic doesn't trigger it.
 
 ### Slow-query alerts: diagnose at the database, not the cluster
-When the App Insights slow-request alert fires (`Zava-products-query-slow`), the bottleneck is almost always at the PostgreSQL layer (missing/disabled index, plan regression, statistics drift), **not** at the pod/CPU/memory layer. Inspect `pg_stat_user_indexes` (low/zero `idx_scan` on a heavily-read table is a strong signal), `pg_stat_user_tables` (high `seq_scan`), and `pg_stat_statements` (top mean-time queries) before looking at AKS resource limits. Use the `bin/run-sql.js` invocation pattern from above to run the diagnostic SQL.
+When the App Insights slow-request alert fires (`Zava-products-query-slow`), the bottleneck is almost always at the PostgreSQL layer (missing/disabled index, plan regression, statistics drift), **not** at the pod/CPU/memory layer. Inspect `pg_stat_user_indexes` (low/zero `idx_scan` on a heavily-read table is a strong signal), `pg_stat_user_tables` (high `seq_scan`), and `pg_stat_statements` (top mean-time queries) before looking at AKS resource limits. Run the diagnostic SQL through the in-cluster helper with native kubectl: `kubectl exec -n zava-demo deploy/zava-api -- node bin/run-sql.js "<SQL>"`.
+
+### Metrics are a first-class signal — three views of the same incident
+For the slow-query failure mode you have logs, metrics, and traces in the shared workspace, and they corroborate each other: the `AppRequests` log signal (`Zava-products-query-slow`), the app's own custom **metric** `zava.products.category.query.duration_ms` in `AppMetrics` (`Zava-category-latency-metric`), and the `AppDependencies` PostgreSQL-call latency (the trace signal). Treat the metric as primary evidence, not decoration — agreement across all three is what points at the database query rather than pods/CPU/memory.
+
+### PostgreSQL saturation metrics are available
+PG Flexible Server platform metrics flow to the workspace via the `AllMetrics` diagnostic setting, queryable in `AzureMetrics` (and surfaced in Metrics Explorer). `cpu_percent`, `active_connections`, `memory_percent`, and IOPS/storage metrics are available for saturation checks. `Zava-db-cpu-saturation` fires on sustained high PG CPU; under a heavy-scan workload it may co-fire with the slow-query signals and corroborates a database-side bottleneck.
+
+### Deployments are an observable signal — correlate 5xx with rollouts
+App regressions are often shipped by a deployment, not caused by infra. Every change to the `zava-api` Deployment's pod template (image, env var, config) creates a new ReplicaSet **revision** — that rollout is a first-class signal. When `Zava-http-5xx-errors` fires and the DB/network/slow-query conditions above do NOT correlate, check whether the 5xx onset lines up with a recent rollout: `kubectl rollout history deployment/zava-api -n zava-demo` for the revision list, and `KubeEvents` / `kubectl get events -n zava-demo` for the `ScalingReplicaSet` timestamps. Note that liveness (`/livez`) and readiness (`/api/health`) can stay green through an app-route regression, so the platform looks healthy while the app is broken — deployment correlation is the signal that ties the spike to its cause. The safe remediation for a deploy-induced regression is a rollback to the previous good revision: `kubectl rollout undo deployment/zava-api -n zava-demo`.


### PR DESCRIPTION
Squashed feature branch. Injects the SRE Agent into a delegated subnet with egress forced through an Azure Firewall (default-deny allow-list); the agent works AKS via native kubectl tools authenticated by its own Entra identity and runs PostgreSQL SQL through an in-cluster app pod (bin/run-sql.js), since the proxy-brokered sandbox egress cannot raw-TCP to private VNet IPs. Adds metrics as a first-class signal: a custom OpenTelemetry latency histogram + slow-query counter emitted by the app, a metric-based alert on it, and a PostgreSQL cpu_percent saturation alert, with runbook/KB treating the metric as a corroborating signal alongside the log alert and pg-call traces. Adds Scenario 4 (bad deploy/rollback): a reversible FAULT_INJECT config rollout the agent correlates to the deployment and remediates with kubectl rollout undo (reuses the existing 5xx alert). KB documents the sandbox egress limitation and that native PG/psql tools cannot reach the private DB.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
