### PR TITLE
feat: add azuretoaws-sre-agent recipe

### DIFF
--- a/sreagent-templates/recipes/azuretoaws-sre-agent/.gitignore
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/.gitignore
@@ -1,0 +1,3 @@
+connectors.secrets.env
+*.secrets.env
+data/

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/README.md
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/README.md
@@ -15,8 +15,20 @@ Includes a diagnostic skill and subagent for investigating serverless app issues
 
 ### Step 1 — Get AWS credentials
 
+Two options depending on your AWS setup:
+
+**Option A: Permanent IAM access key (simplest, no expiration)**
+
+1. In the AWS Console, go to IAM → Users → create a user with programmatic access
+2. Attach `ReadOnlyAccess` policy (or a scoped policy for CloudWatch, Lambda, DynamoDB, X-Ray)
+3. Under Security credentials, create an access key
+4. Use the Access Key ID and Secret Access Key directly, leave `AWS_SESSION_TOKEN` empty
+
+**Option B: Temporary STS credentials (short-lived)**
+
+If you already have an IAM user with permanent keys, generate temporary credentials:
+
 ```bash
-# Generate short-lived STS credentials (12 hours)
 aws sts get-session-token --duration-seconds 43200 --output json
 ```
 
@@ -80,11 +92,11 @@ EOF
 
 These go in the secrets file, **never** on the command line:
 
-| Variable | Source | Notes |
-|----------|--------|-------|
-| `AWS_ACCESS_KEY_ID` | `aws sts get-session-token` | Temporary key |
-| `AWS_SECRET_ACCESS_KEY` | `aws sts get-session-token` | Temporary secret |
-| `AWS_SESSION_TOKEN` | `aws sts get-session-token` | Session token (required for STS creds) |
+| Variable | Notes |
+|----------|-------|
+| `AWS_ACCESS_KEY_ID` | Permanent key (starts with `AKIA`) or temporary key (starts with `ASIA`) |
+| `AWS_SECRET_ACCESS_KEY` | Corresponding secret key |
+| `AWS_SESSION_TOKEN` | Required for temporary STS creds. Leave empty if using permanent IAM key |
 
 ### Advanced Options
 
@@ -130,15 +142,14 @@ Provides AWS documentation, best practices, code samples, and regional availabil
 
 ## Credential Rotation
 
-STS credentials expire (default 12 hours). To rotate:
+**Permanent IAM keys:** No expiration. Rotate periodically per your security policy (IAM → User → Security credentials → Create new key → delete old key). No redeploy needed if you delete and recreate the connector in the portal with the new values.
+
+**Temporary STS credentials:** Expire after your configured session duration. To rotate:
 
 1. Generate new credentials: `aws sts get-session-token --duration-seconds 43200`
-2. Update `connectors.secrets.env` with new values
-3. Redeploy: `./bin/deploy.sh aws-agent/`
+2. Delete the `aws-mcp` connector in Builder and re-add it with the new values (this forces a fresh proxy process)
 
-For production use, consider:
-- AWS IAM Roles Anywhere (X.509 certificate-based, no manual rotation)
-- A scheduled task that rotates credentials automatically
+For production use, consider AWS IAM Roles Anywhere (X.509 certificate-based, no manual rotation).
 
 ## Via Portal (no IaC)
 

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/README.md
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/README.md
@@ -1,0 +1,158 @@
+# azuretoaws-sre-agent
+
+SRE Agent connected to AWS resources via the AWS MCP SDK. Uses CloudWatch for
+observability (logs, metrics, alarms, X-Ray traces) instead of third-party APM tools.
+Includes a diagnostic skill and subagent for investigating serverless app issues.
+
+## Prerequisites
+
+- AWS account with IAM access (STS temporary credentials recommended)
+- GitHub repo with your AWS app source code
+- Azure subscription with a resource group for the agent
+- All [CLI tools](../../README.md#prerequisites) installed (`./bin/install-prerequisites.sh --check`)
+
+## Quick Start
+
+### Step 1 — Get AWS credentials
+
+```bash
+# Generate short-lived STS credentials (12 hours)
+aws sts get-session-token --duration-seconds 43200 --output json
+```
+
+Save `AccessKeyId`, `SecretAccessKey`, and `SessionToken` from the output.
+
+### Step 2 — Generate agent config
+
+Bash:
+
+```bash
+./bin/new-agent.sh --recipe azuretoaws-sre-agent --non-interactive \
+  --set agentName=aws-sre-agent \
+  --set resourceGroup=rg-aws-sre-agent \
+  --set location=eastus2 \
+  --set awsRegion=us-east-1 \
+  --set githubRepo=https://github.com/dm-chelupati/todo-app-dynatrace-aws.git \
+  -o aws-agent/
+```
+
+PowerShell:
+
+```powershell
+./bin/ps/New-Agent.ps1 -Recipe azuretoaws-sre-agent -NonInteractive `
+  -Set @{agentName='aws-sre-agent'; resourceGroup='rg-aws-sre-agent'; location='eastus2';
+    awsRegion='us-east-1'; githubRepo='https://github.com/dm-chelupati/todo-app-dynatrace-aws.git'} `
+  -Output aws-agent/
+```
+
+### Step 3 — Add AWS credentials to secrets file
+
+```bash
+# Edit the generated secrets file (gitignored, never committed)
+cat > aws-agent/connectors.secrets.env << 'EOF'
+AWS_ACCESS_KEY_ID=<paste AccessKeyId from Step 1>
+AWS_SECRET_ACCESS_KEY=<paste SecretAccessKey from Step 1>
+AWS_SESSION_TOKEN=<paste SessionToken from Step 1>
+EOF
+```
+
+### Step 4 — Deploy (pick any backend)
+
+| Backend | Command |
+|---------|---------|
+| Bicep | `./bin/deploy.sh aws-agent/` |
+| Terraform | `./bin/deploy-tf.sh aws-agent/` |
+| PowerShell | `./bin/ps/Deploy-Agent.ps1 -InputPath aws-agent/` |
+| azd | `azd up` (see main README for setup) |
+
+## Parameters
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| agentName | Yes | `aws-sre-agent` | Lowercase, hyphens ok |
+| resourceGroup | Yes | `rg-aws-sre-agent` | Azure RG for agent infra |
+| location | Yes | | Azure region for the agent (eastus2, swedencentral, etc.) |
+| awsRegion | Yes | `us-east-1` | AWS region where your workloads are deployed (determines MCP endpoint + SigV4 signing) |
+| githubRepo | No | `dm-chelupati/todo-app-dynatrace-aws` | GitHub repo for code context |
+| targetRGs | No | | Azure RGs to monitor (comma-separated, leave empty for AWS-only) |
+
+### Secrets (connectors.secrets.env)
+
+These go in the secrets file, **never** on the command line:
+
+| Variable | Source | Notes |
+|----------|--------|-------|
+| `AWS_ACCESS_KEY_ID` | `aws sts get-session-token` | Temporary key |
+| `AWS_SECRET_ACCESS_KEY` | `aws sts get-session-token` | Temporary secret |
+| `AWS_SESSION_TOKEN` | `aws sts get-session-token` | Session token (required for STS creds) |
+
+### Advanced Options
+
+| Parameter | Default | Notes |
+|-----------|---------|-------|
+| existingUamiId | (create new) | ARM resource ID of existing UAMI |
+| existingAgentAppInsightsId | (create new) | ARM resource ID of existing App Insights |
+| modelProvider | Anthropic | AI model provider (Anthropic or Azure OpenAI) |
+
+## What You Get
+
+| Component | Details |
+|-----------|---------|
+| Connectors | AWS MCP (stdio, SigV4 via mcp-proxy-for-aws), AWS Knowledge MCP (remote, no auth) |
+| Skills | `investigate-aws-app-errors` — CloudWatch + Lambda + DynamoDB diagnostics |
+| Subagents | `aws-investigator` — autonomous investigation using AWS MCP tools |
+| Hooks | `deny-aws-destructive` — blocks delete/terminate/remove without approval |
+| Common Prompts | `safety-rules` — AWS-specific safety guardrails |
+| Repos | GitHub repo connected for code context |
+
+## How It Works
+
+### AWS MCP Server (stdio connector)
+
+The agent spawns `mcp-proxy-for-aws` as a child process inside its container. This proxy:
+1. Receives tool calls from the agent
+2. Signs them with SigV4 using the AWS credentials you provide
+3. Forwards to `https://aws-mcp.<region>.api.aws/mcp`
+4. Returns results (CloudWatch logs, Lambda config, DynamoDB state, etc.)
+
+### AWS Knowledge MCP Server (remote connector)
+
+Direct HTTPS connection to `https://knowledge-mcp.global.api.aws`. No auth required.
+Provides AWS documentation, best practices, code samples, and regional availability info.
+
+## After Deploy
+
+1. Open [SRE Agent portal](https://sre.azure.com/) → verify agent shows "Running"
+2. Go to **Connectors** → verify both `aws-mcp` and `aws-knowledge` show "Connected"
+3. Go to **Repos** → verify GitHub repo is linked
+4. Test with a prompt:
+   > "Check CloudWatch for any Lambda errors in the todo-app-api function in the last 24 hours"
+
+## Credential Rotation
+
+STS credentials expire (default 12 hours). To rotate:
+
+1. Generate new credentials: `aws sts get-session-token --duration-seconds 43200`
+2. Update `connectors.secrets.env` with new values
+3. Redeploy: `./bin/deploy.sh aws-agent/`
+
+For production use, consider:
+- AWS IAM Roles Anywhere (X.509 certificate-based, no manual rotation)
+- A scheduled task that rotates credentials automatically
+
+## Via Portal (no IaC)
+
+If you prefer to configure via the SRE Agent portal instead of recipes:
+
+1. **Create agent** at sre.azure.com → New Agent
+2. **Add AWS MCP connector** → Builder → Connectors → Add → MCP Server → Process (stdio)
+   - Command: `uvx`
+   - Args: `mcp-proxy-for-aws@1.6.0 https://aws-mcp.us-east-1.api.aws/mcp --region us-east-1`
+   - Env: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`
+3. **Add AWS Knowledge connector** → Add → MCP Server → Remote (URL)
+   - URL: `https://knowledge-mcp.global.api.aws`
+   - Auth: None
+4. **Add GitHub repo** → Repos → Add → paste repo URL
+5. **Create skill** → Skills → Add → paste YAML from `config/skills/`
+6. **Create subagent** → Subagents → Add → paste YAML from `config/subagents/`
+7. **Add hook** → Hooks → Add → paste YAML from `config/hooks/`

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/agent.json
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/agent.json
@@ -1,0 +1,79 @@
+{
+  "_scenario": "azuretoaws-sre-agent",
+  "_description": "SRE Agent connected to AWS resources via AWS MCP SDK. Uses CloudWatch for observability, connects to Lambda/DynamoDB/S3 workloads, and GitHub for code context. AWS credentials go in connectors.secrets.env (never on command line).",
+  "_prerequisites": [
+    "AWS account with IAM access (STS temporary credentials recommended)",
+    "GitHub repo with your AWS app source code",
+    "Azure subscription with a resource group for the agent"
+  ],
+  "_prompts": {
+    "agentName": {
+      "ask": "Agent name",
+      "default": "aws-sre-agent"
+    },
+    "resourceGroup": {
+      "ask": "Resource group for the agent",
+      "default": "rg-aws-sre-agent"
+    },
+    "location": {
+      "ask": "Region",
+      "options": [
+        "eastus2",
+        "swedencentral",
+        "uksouth",
+        "australiaeast"
+      ],
+      "required": true
+    },
+    "targetRGs": {
+      "ask": "Azure resource groups to monitor (comma-separated, can be empty for AWS-only)",
+      "default": ""
+    },
+    "awsRegion": {
+      "ask": "AWS region where your workloads run",
+      "default": "us-east-1"
+    },
+
+    "githubRepo": {
+      "ask": "GitHub repo URL (e.g. https://github.com/org/repo.git)",
+      "default": "https://github.com/dm-chelupati/todo-app-dynatrace-aws.git"
+    },
+    "existingUamiId": {
+      "ask": "Existing UAMI resource ID (leave blank to create new)",
+      "default": ""
+    },
+    "modelProvider": {
+      "ask": "AI model provider",
+      "options": [
+        "Anthropic",
+        "Azure OpenAI"
+      ],
+      "default": "Anthropic"
+    },
+    "existingAgentAppInsightsId": {
+      "ask": "Existing App Insights resource ID for agent telemetry (leave blank to create new)",
+      "default": ""
+    }
+  },
+  "identity": {
+    "agentName": "{{agentName}}",
+    "resourceGroup": "{{resourceGroup}}",
+    "subscription": "",
+    "location": "{{location}}",
+    "targetResourceGroups": "{{targetRGs}}"
+  },
+  "access": {
+    "accessLevel": "Low",
+    "actionMode": "Review"
+  },
+  "upgradeChannel": "Preview",
+  "defaultModelProvider": "{{modelProvider}}",
+  "monthlyAgentUnitLimit": 10000,
+  "tags": {},
+  "toggles": {
+    "enableWebhookBridge": false,
+    "webhookBridgeTriggerUrl": ""
+  },
+  "existingUamiId": "{{existingUamiId}}",
+  "existingAgentAppInsightsId": "{{existingAgentAppInsightsId}}"
+}

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/config/common-prompts/safety-rules.md
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/config/common-prompts/safety-rules.md
@@ -1,0 +1,8 @@
+## Safety rules
+
+- Never modify or delete AWS resources without explicit human approval.
+- Never expose AWS credentials, tokens, or secrets in responses.
+- Prefer read-only operations (describe, list, get-log-events) during investigation.
+- For any write operation, explain intent and wait for approval.
+- Rate-limit CloudWatch API calls where possible.
+- Always confirm target account and region before any AWS operation.

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/config/common-prompts/safety-rules.yaml
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/config/common-prompts/safety-rules.yaml
@@ -1,0 +1,17 @@
+metadata:
+  name: safety-rules
+spec:
+  prompt: '## Safety rules
+
+
+    - Never modify or delete AWS resources without explicit human approval.
+
+    - Never expose AWS credentials, tokens, or secrets in responses.
+
+    - Prefer read-only operations (describe, list, get-log-events) during investigation.
+
+    - For any write operation, explain intent and wait for approval.
+
+    - Rate-limit CloudWatch API calls where possible.
+
+    - Always confirm target account and region before any AWS operation.'

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/config/hooks/deny-aws-destructive.yaml
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/config/hooks/deny-aws-destructive.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: deny-aws-destructive
+spec:
+  eventType: PreToolUse
+  hook:
+    type: prompt
+    prompt: If the tool targets a production AWS resource (deleting, terminating, or
+      removing), deny the action and require explicit human approval.
+    matcher: ^aws-mcp_(delete|terminate|remove|destroy|stop).*
+  permissionDecision: deny
+  enabled: true

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/config/repos/github-repo.yaml
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/config/repos/github-repo.yaml
@@ -1,0 +1,5 @@
+name: todo-app-aws
+spec:
+  url: "{{githubRepo}}"
+  branch: main
+  description: Serverless todo app with Lambda, DynamoDB, S3, API Gateway, CloudWatch observability

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/config/skills/investigate-aws-app-errors.md
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/config/skills/investigate-aws-app-errors.md
@@ -1,0 +1,224 @@
+# AWS Serverless App Diagnostic Skill
+
+## Architecture Context
+
+This skill investigates a serverless todo application on AWS with:
+- **Frontend**: S3 static website
+- **API**: API Gateway (HTTP API) + Lambda (Python)
+- **Database**: DynamoDB (pay-per-request)
+- **Observability**: CloudWatch Logs, CloudWatch Metrics, X-Ray traces, CloudWatch Alarms
+- **Alerts**: CloudWatch Alarms → SNS → Email
+- **IaC**: Terraform
+- **CI/CD**: GitHub Actions
+
+## Key Resources
+
+| Resource | Name/Pattern |
+|----------|-------------|
+| Lambda function | `todo-app-api` |
+| DynamoDB table | `todo-app-todos` |
+| CloudWatch log group | `/aws/lambda/todo-app-api` |
+| API Gateway | `todo-app-api` |
+| S3 bucket | `todo-app-frontend-*` |
+| CloudWatch Alarms | `todo-app-lambda-errors`, `todo-app-lambda-duration`, `todo-app-lambda-throttles` |
+
+## Investigation Playbook
+
+### Step 1 — Gather Signals
+
+1. **Check CloudWatch Alarms** — look for any alarms in ALARM state
+2. **Query CloudWatch Logs** — filter `/aws/lambda/todo-app-api` for ERROR level
+3. **Check Lambda metrics** — invocations, errors, duration, throttles
+4. **Check DynamoDB metrics** — read/write capacity, system errors, throttled requests
+
+### Step 2 — Correlate with Code
+
+1. Look at the Lambda handler in `app/lambda/` for the error path
+2. Check recent commits/PRs in the GitHub repo for related changes
+3. Cross-reference error timestamps with deployment timestamps from GitHub Actions
+
+### Step 3 — Diagnose
+
+Common failure patterns:
+- **Lambda timeout**: Check duration metric + CloudWatch Logs for slow DynamoDB calls
+- **DynamoDB throttling**: Check consumed vs provisioned capacity
+- **Cold starts**: Check init duration in Lambda platform logs
+- **API Gateway 5xx**: Check Lambda errors metric + integration timeout
+- **Missing env vars**: Check Lambda configuration for TABLE_NAME, REGION references
+
+### Step 4 — Use AWS Knowledge Base
+
+Query the AWS Knowledge MCP server for:
+- Best practices for Lambda error handling
+- DynamoDB capacity planning guidance
+- CloudWatch alarm configuration recommendations
+- X-Ray trace analysis patterns
+
+## API Endpoints Under Investigation
+
+| Method | Path | Lambda Handler |
+|--------|------|---------------|
+| GET | `/todos` | `handler.get_todos` |
+| POST | `/todos` | `handler.create_todo` |
+| PUT | `/todos/{id}` | `handler.update_todo` |
+| DELETE | `/todos/{id}` | `handler.delete_todo` |
+
+## CloudWatch Insights Query Patterns
+
+```
+# Find errors in last hour
+fields @timestamp, @message
+| filter @message like /ERROR/
+| sort @timestamp desc
+| limit 50
+
+# Find slow invocations (>3s)
+fields @timestamp, @duration, @requestId
+| filter @duration > 3000
+| sort @duration desc
+
+# Find cold starts
+fields @timestamp, @initDuration, @duration
+| filter ispresent(@initDuration)
+| sort @timestamp desc
+
+# DynamoDB errors
+fields @timestamp, @message
+| filter @message like /DynamoDB/ and @message like /Error|Exception|Timeout/
+| sort @timestamp desc
+```
+
+## Terraform Resources (for infrastructure context)
+
+The infrastructure is defined in `terraform/` with key files:
+- `main.tf` — Lambda, API Gateway, DynamoDB, S3
+- `monitoring.tf` — CloudWatch alarms, dashboards, SNS
+- `variables.tf` — Configuration parameters
+- `outputs.tf` — API endpoint, S3 URL, resource ARNs
+
+---
+
+# AWS Serverless App Architecture — Investigation Guide
+
+## Purpose
+
+This knowledge file teaches the agent how to discover, map, and investigate AWS serverless applications. Do NOT assume resource names. Always discover them at runtime using the AWS MCP tools.
+
+## Architecture Pattern: Serverless Web App on AWS
+
+Typical stack:
+- **Frontend**: S3 static website or CloudFront distribution
+- **API**: API Gateway (HTTP API or REST API) routing to Lambda
+- **Compute**: Lambda functions (Python, Node.js, Go, etc.)
+- **Database**: DynamoDB, RDS, or Aurora Serverless
+- **Observability**: CloudWatch Logs + Metrics + Alarms + X-Ray
+- **Alerts**: CloudWatch Alarms → SNS → Email/PagerDuty/Slack
+
+## Discovery Process
+
+Always start by discovering what exists before investigating. Never assume names.
+
+### Step 1 — Discover Lambda Functions
+- List all functions in the region
+- For each function, get its configuration (runtime, timeout, memory, env vars, VPC)
+- Note which functions share a naming prefix (likely same app)
+
+### Step 2 — Discover API Gateway
+- List APIs to find which front the Lambda functions
+- Check integration targets to map routes → functions
+
+### Step 3 — Discover DynamoDB Tables
+- List tables, then describe each to get key schema, billing mode, indexes
+- Cross-reference with Lambda env vars (usually TABLE_NAME or similar)
+
+### Step 4 — Discover CloudWatch Configuration
+- List alarms to find what thresholds are configured
+- List log groups matching `/aws/lambda/<function-name>`
+- Check for custom metric namespaces
+
+### Step 5 — Check Source Code (GitHub)
+- Look at the connected repo for IaC files (Terraform, CDK, SAM, CloudFormation)
+- IaC files are the source of truth for what SHOULD exist
+- Compare deployed state vs IaC definition to find drift
+
+## Observability Signals and Where to Find Them
+
+### CloudWatch Logs
+- **Log groups**: `/aws/lambda/<function-name>` (auto-created per function)
+- **Structured logs**: Look for JSON-formatted messages with level, requestId, message
+- **Platform events**: START, END, REPORT lines contain duration, memory used, init duration
+- **Error detection**: Filter for ERROR, Exception, Traceback, stackTrace
+
+### CloudWatch Metrics
+- **Lambda namespace** (`AWS/Lambda`):
+  - `Invocations` — total calls
+  - `Errors` — unhandled exceptions or explicit failures
+  - `Duration` — execution time
+  - `Throttles` — concurrency limit exceeded
+  - `ConcurrentExecutions` — active instances
+  - `IteratorAge` — for stream-triggered functions
+- **DynamoDB namespace** (`AWS/DynamoDB`):
+  - `ConsumedReadCapacityUnits` / `ConsumedWriteCapacityUnits`
+  - `ThrottledRequests`
+  - `SystemErrors`
+  - `SuccessfulRequestLatency`
+- **API Gateway namespace** (`AWS/ApiGateway`):
+  - `4XXError`, `5XXError`
+  - `Latency`, `IntegrationLatency`
+  - `Count`
+- **Custom namespaces**: App-specific metrics (discover via list-metrics)
+
+### CloudWatch Alarms
+- Check alarm state: OK, ALARM, INSUFFICIENT_DATA
+- Check alarm history for recent state transitions
+- Alarm actions tell you who gets notified (SNS topic ARN)
+
+### X-Ray Traces
+- Trace summaries show end-to-end latency and error rates
+- Individual traces show per-segment timing (API GW → Lambda → DynamoDB)
+- Filter by annotation, duration, status code, or time range
+
+## Common Failure Patterns
+
+### Lambda Failures
+| Symptom | What to Check | Likely Cause |
+|---------|--------------|--------------|
+| High error rate | Logs for stack traces | Code bug, missing dependency, bad env var |
+| Timeout | Duration metric, log for slow operations | Downstream latency (DB, external API) |
+| Throttle | ConcurrentExecutions metric | Reached account/function concurrency limit |
+| Cold start spikes | REPORT lines with initDuration | VPC ENI attach, large package, runtime init |
+| Out of memory | REPORT lines showing max memory used | Increase memory configuration |
+
+### DynamoDB Failures
+| Symptom | What to Check | Likely Cause |
+|---------|--------------|--------------|
+| Throttled requests | ThrottledRequests metric | Hot partition, burst capacity exhausted |
+| High latency | SuccessfulRequestLatency | Large items, query without index |
+| System errors | SystemErrors metric | AWS-side issue (rare, check Service Health) |
+| Validation errors | Lambda logs | Bad key schema, missing required attributes |
+
+### API Gateway Failures
+| Symptom | What to Check | Likely Cause |
+|---------|--------------|--------------|
+| 5xx errors | Integration latency, Lambda errors | Lambda failing or timing out |
+| 4xx errors | Access logs | Client sending bad requests, CORS, auth |
+| High latency | Latency vs IntegrationLatency | If equal: Lambda slow. If gateway higher: routing overhead |
+
+## Investigation Methodology
+
+1. **Time-bound**: Always establish the time window (when did it start, is it ongoing?)
+2. **Scope**: Which functions/tables/APIs are affected? One or many?
+3. **Correlate**: Did anything change? Check GitHub commits, deployments, config changes near the start time
+4. **Quantify**: What's the error rate? What percentage of requests are affected?
+5. **Root cause vs symptom**: Lambda errors are symptoms. The root cause is in the code, config, or downstream dependency
+6. **Evidence**: Always provide specific log lines, metric values, or trace IDs as evidence
+
+## Source Code Patterns to Look For
+
+When you have access to the GitHub repo:
+- **IaC files** (Terraform/CDK/SAM): Ground truth for intended infrastructure
+- **Handler code**: Entry points, error handling, retry logic
+- **Dependencies**: requirements.txt, package.json — version issues, missing packages
+- **CI/CD workflows**: .github/workflows/ — deployment process, what triggers deploys
+- **Environment config**: How env vars are set, what values are expected
+- **Recent commits**: Changes near the incident start time are prime suspects

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/config/skills/investigate-aws-app-errors.yaml
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/config/skills/investigate-aws-app-errors.yaml
@@ -1,0 +1,26 @@
+metadata:
+  name: investigate-aws-app-errors
+  description: Investigate errors and performance issues in AWS serverless applications
+    using CloudWatch Logs, Lambda metrics, DynamoDB operations, and X-Ray traces.
+  spec:
+    tools:
+    - SearchMemory
+    - ExecutePythonCode
+    - PlotAreaChartWithCorrelation
+    - PlotBarChart
+    - aws-mcp_cloudwatch_get-log-events
+    - aws-mcp_cloudwatch_filter-log-events
+    - aws-mcp_cloudwatch_describe-alarms
+    - aws-mcp_cloudwatch_get-metric-data
+    - aws-mcp_cloudwatch_list-metrics
+    - aws-mcp_lambda_get-function
+    - aws-mcp_lambda_list-functions
+    - aws-mcp_lambda_get-function-configuration
+    - aws-mcp_dynamodb_describe-table
+    - aws-mcp_dynamodb_list-tables
+    - aws-mcp_xray_get-trace-summaries
+    - aws-mcp_xray_batch-get-traces
+    - aws-knowledge_search
+    - aws-knowledge_get-content
+skillContent: skills/investigate-aws-app-errors.md
+additionalFiles: []

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/config/subagents/aws-investigator.instructions.md
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/config/subagents/aws-investigator.instructions.md
@@ -1,0 +1,44 @@
+# AWS Investigator
+
+You are an AWS infrastructure investigator specialized in serverless applications running on Lambda, API Gateway, DynamoDB, and S3.
+
+## Your Role
+
+Diagnose issues by correlating signals across:
+- **CloudWatch Logs** — application and Lambda platform logs
+- **CloudWatch Metrics** — Lambda duration/errors/throttles, DynamoDB capacity
+- **CloudWatch Alarms** — alarm state transitions and history
+- **X-Ray Traces** — distributed tracing across Lambda, API Gateway, DynamoDB
+- **AWS Knowledge Base** — best practices and documentation
+- **Source Code** — GitHub repo for recent changes and code context
+
+## Investigation Process
+
+1. **Start with alarms** — check which CloudWatch Alarms are in ALARM state
+2. **Query logs** — look at the Lambda log group for errors around the trigger time
+3. **Check metrics** — correlate with Lambda invocation metrics and DynamoDB metrics
+4. **Trace requests** — use X-Ray trace data to find the exact failing request path
+5. **Cross-reference code** — check the GitHub repo for recent changes that could explain the failure
+6. **Recommend fix** — provide actionable remediation with specific code/config changes
+
+## Rules
+
+- Always start with read-only operations
+- Never modify AWS resources without explicit approval
+- Present evidence (log snippets, metric values, trace IDs) with every finding
+- Distinguish between symptoms and root causes
+- If you cannot determine root cause, say so and suggest what additional access would help
+
+## Common Patterns
+
+### Lambda Errors
+- Check error rate metric → query logs for stack traces → identify handler/dependency issue
+- Cold start issues: look for `@initDuration` in platform logs
+
+### DynamoDB Issues
+- Throttling: check `ConsumedReadCapacityUnits` vs provisioned
+- Latency: check `SuccessfulRequestLatency` metric
+
+### API Gateway
+- 5xx errors: usually Lambda timeout or unhandled exception
+- 4xx errors: usually client-side (bad request, missing auth)

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/config/subagents/aws-investigator.yaml
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/config/subagents/aws-investigator.yaml
@@ -1,0 +1,37 @@
+metadata:
+  name: aws-investigator
+spec:
+  instructions: subagents/aws-investigator.instructions.md
+  handoffDescription: Investigates AWS infrastructure issues using CloudWatch logs,
+    metrics, alarms, X-Ray traces, and source code analysis.
+  enableSkills: true
+  allowedSkills:
+  - investigate-aws-app-errors
+  tools:
+  - SearchMemory
+  - ExecutePythonCode
+  - CreateGithubIssue
+  - FetchGithubIssues
+  - FindConnectedGitHubRepo
+  - PlotAreaChartWithCorrelation
+  - PlotBarChart
+  - PlotHeatmap
+  - aws-mcp_cloudwatch_get-log-events
+  - aws-mcp_cloudwatch_filter-log-events
+  - aws-mcp_cloudwatch_describe-alarms
+  - aws-mcp_cloudwatch_get-metric-data
+  - aws-mcp_cloudwatch_list-metrics
+  - aws-mcp_cloudwatch_start-query
+  - aws-mcp_cloudwatch_get-query-results
+  - aws-mcp_lambda_get-function
+  - aws-mcp_lambda_list-functions
+  - aws-mcp_lambda_get-function-configuration
+  - aws-mcp_dynamodb_describe-table
+  - aws-mcp_dynamodb_list-tables
+  - aws-mcp_xray_get-trace-summaries
+  - aws-mcp_xray_batch-get-traces
+  - aws-mcp_s3_list-buckets
+  - aws-mcp_s3_get-bucket-location
+  - aws-knowledge_search
+  - aws-knowledge_get-content
+  agentType: Autonomous

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/connectors.json
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/connectors.json
@@ -1,0 +1,50 @@
+{
+  "toggles": {
+    "enableAppInsightsConnector": false,
+    "appInsightsResourceId": "",
+    "appInsightsAppId": "",
+    "enableLogAnalyticsConnector": false,
+    "lawResourceId": "",
+    "enableAzureMonitorConnector": false,
+    "azureMonitorLookbackDays": 7,
+    "grafanaUrl": "",
+    "grafanaApiKey": ""
+  },
+  "connectors": [
+    {
+      "name": "aws-mcp",
+      "properties": {
+        "dataConnectorType": "Mcp",
+        "dataSource": "placeholder",
+        "extendedProperties": {
+          "type": "stdio",
+          "command": "uvx",
+          "args": ["mcp-proxy-for-aws@1.6.0", "https://aws-mcp.{{awsRegion}}.api.aws/mcp", "--region", "{{awsRegion}}"],
+          "envs": {
+            "AWS_ACCESS_KEY_ID": "${AWS_ACCESS_KEY_ID}",
+            "AWS_SECRET_ACCESS_KEY": "${AWS_SECRET_ACCESS_KEY}",
+            "AWS_SESSION_TOKEN": "${AWS_SESSION_TOKEN}",
+            "AWS_REGION": "{{awsRegion}}"
+          },
+          "toolsVisibleToMetaAgent": ["*"],
+          "selectedTools": ["*"]
+        },
+        "identity": "system"
+      }
+    },
+    {
+      "name": "aws-knowledge",
+      "properties": {
+        "dataConnectorType": "Mcp",
+        "dataSource": "placeholder",
+        "extendedProperties": {
+          "type": "http",
+          "endpoint": "https://knowledge-mcp.global.api.aws",
+          "toolsVisibleToMetaAgent": ["*"],
+          "selectedTools": ["*"]
+        },
+        "identity": "system"
+      }
+    }
+  ]
+}

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/connectors.secrets.env.example
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/connectors.secrets.env.example
@@ -1,0 +1,13 @@
+# AWS credentials for the aws-mcp stdio connector
+# Copy this file to connectors.secrets.env and fill in your values:
+#   cp connectors.secrets.env.example connectors.secrets.env
+#
+# Get credentials from:
+#   - IAM Identity Center: AWS access portal → your account → "Command line or programmatic access" → Option 1
+#   - IAM User: aws sts get-session-token --duration-seconds 43200 (requires permanent IAM user keys)
+#
+# NEVER commit connectors.secrets.env — it is gitignored
+
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_SESSION_TOKEN=

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/data/knowledge/aws-app-architecture.md
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/data/knowledge/aws-app-architecture.md
@@ -1,0 +1,124 @@
+# AWS Serverless App Architecture — Investigation Guide
+
+## Purpose
+
+This knowledge file teaches the agent how to discover, map, and investigate AWS serverless applications. Do NOT assume resource names. Always discover them at runtime using the AWS MCP tools.
+
+## Architecture Pattern: Serverless Web App on AWS
+
+Typical stack:
+- **Frontend**: S3 static website or CloudFront distribution
+- **API**: API Gateway (HTTP API or REST API) routing to Lambda
+- **Compute**: Lambda functions (Python, Node.js, Go, etc.)
+- **Database**: DynamoDB, RDS, or Aurora Serverless
+- **Observability**: CloudWatch Logs + Metrics + Alarms + X-Ray
+- **Alerts**: CloudWatch Alarms → SNS → Email/PagerDuty/Slack
+
+## Discovery Process
+
+Always start by discovering what exists before investigating. Never assume names.
+
+### Step 1 — Discover Lambda Functions
+- List all functions in the region
+- For each function, get its configuration (runtime, timeout, memory, env vars, VPC)
+- Note which functions share a naming prefix (likely same app)
+
+### Step 2 — Discover API Gateway
+- List APIs to find which front the Lambda functions
+- Check integration targets to map routes → functions
+
+### Step 3 — Discover DynamoDB Tables
+- List tables, then describe each to get key schema, billing mode, indexes
+- Cross-reference with Lambda env vars (usually TABLE_NAME or similar)
+
+### Step 4 — Discover CloudWatch Configuration
+- List alarms to find what thresholds are configured
+- List log groups matching `/aws/lambda/<function-name>`
+- Check for custom metric namespaces
+
+### Step 5 — Check Source Code (GitHub)
+- Look at the connected repo for IaC files (Terraform, CDK, SAM, CloudFormation)
+- IaC files are the source of truth for what SHOULD exist
+- Compare deployed state vs IaC definition to find drift
+
+## Observability Signals and Where to Find Them
+
+### CloudWatch Logs
+- **Log groups**: `/aws/lambda/<function-name>` (auto-created per function)
+- **Structured logs**: Look for JSON-formatted messages with level, requestId, message
+- **Platform events**: START, END, REPORT lines contain duration, memory used, init duration
+- **Error detection**: Filter for ERROR, Exception, Traceback, stackTrace
+
+### CloudWatch Metrics
+- **Lambda namespace** (`AWS/Lambda`):
+  - `Invocations` — total calls
+  - `Errors` — unhandled exceptions or explicit failures
+  - `Duration` — execution time
+  - `Throttles` — concurrency limit exceeded
+  - `ConcurrentExecutions` — active instances
+  - `IteratorAge` — for stream-triggered functions
+- **DynamoDB namespace** (`AWS/DynamoDB`):
+  - `ConsumedReadCapacityUnits` / `ConsumedWriteCapacityUnits`
+  - `ThrottledRequests`
+  - `SystemErrors`
+  - `SuccessfulRequestLatency`
+- **API Gateway namespace** (`AWS/ApiGateway`):
+  - `4XXError`, `5XXError`
+  - `Latency`, `IntegrationLatency`
+  - `Count`
+- **Custom namespaces**: App-specific metrics (discover via list-metrics)
+
+### CloudWatch Alarms
+- Check alarm state: OK, ALARM, INSUFFICIENT_DATA
+- Check alarm history for recent state transitions
+- Alarm actions tell you who gets notified (SNS topic ARN)
+
+### X-Ray Traces
+- Trace summaries show end-to-end latency and error rates
+- Individual traces show per-segment timing (API GW → Lambda → DynamoDB)
+- Filter by annotation, duration, status code, or time range
+
+## Common Failure Patterns
+
+### Lambda Failures
+| Symptom | What to Check | Likely Cause |
+|---------|--------------|--------------|
+| High error rate | Logs for stack traces | Code bug, missing dependency, bad env var |
+| Timeout | Duration metric, log for slow operations | Downstream latency (DB, external API) |
+| Throttle | ConcurrentExecutions metric | Reached account/function concurrency limit |
+| Cold start spikes | REPORT lines with initDuration | VPC ENI attach, large package, runtime init |
+| Out of memory | REPORT lines showing max memory used | Increase memory configuration |
+
+### DynamoDB Failures
+| Symptom | What to Check | Likely Cause |
+|---------|--------------|--------------|
+| Throttled requests | ThrottledRequests metric | Hot partition, burst capacity exhausted |
+| High latency | SuccessfulRequestLatency | Large items, query without index |
+| System errors | SystemErrors metric | AWS-side issue (rare, check Service Health) |
+| Validation errors | Lambda logs | Bad key schema, missing required attributes |
+
+### API Gateway Failures
+| Symptom | What to Check | Likely Cause |
+|---------|--------------|--------------|
+| 5xx errors | Integration latency, Lambda errors | Lambda failing or timing out |
+| 4xx errors | Access logs | Client sending bad requests, CORS, auth |
+| High latency | Latency vs IntegrationLatency | If equal: Lambda slow. If gateway higher: routing overhead |
+
+## Investigation Methodology
+
+1. **Time-bound**: Always establish the time window (when did it start, is it ongoing?)
+2. **Scope**: Which functions/tables/APIs are affected? One or many?
+3. **Correlate**: Did anything change? Check GitHub commits, deployments, config changes near the start time
+4. **Quantify**: What's the error rate? What percentage of requests are affected?
+5. **Root cause vs symptom**: Lambda errors are symptoms. The root cause is in the code, config, or downstream dependency
+6. **Evidence**: Always provide specific log lines, metric values, or trace IDs as evidence
+
+## Source Code Patterns to Look For
+
+When you have access to the GitHub repo:
+- **IaC files** (Terraform/CDK/SAM): Ground truth for intended infrastructure
+- **Handler code**: Entry points, error handling, retry logic
+- **Dependencies**: requirements.txt, package.json — version issues, missing packages
+- **CI/CD workflows**: .github/workflows/ — deployment process, what triggers deploys
+- **Environment config**: How env vars are set, what values are expected
+- **Recent commits**: Changes near the incident start time are prime suspects

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/expected-config.json
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/expected-config.json
@@ -1,0 +1,12 @@
+{
+  "agent": true,
+  "connectors": 2,
+  "skills": 1,
+  "subagents": 1,
+  "hooks": 1,
+  "common-prompts": 1,
+  "repos": 1,
+  "scheduled-tasks": 0,
+  "incident-filters": 0,
+  "incident-platforms": 0
+}

--- a/sreagent-templates/recipes/azuretoaws-sre-agent/roles.yaml
+++ b/sreagent-templates/recipes/azuretoaws-sre-agent/roles.yaml
@@ -1,0 +1,12 @@
+# Role assignments for azuretoaws recipe
+#
+# AWS credentials: Generate STS temporary credentials
+#   aws sts get-session-token --duration-seconds 43200
+#   Copy AccessKeyId, SecretAccessKey, SessionToken into connectors.secrets.env
+#
+# GitHub repo: Configure in portal after deploy, or use GitHub App integration
+
+roles:
+  - scope: "/subscriptions/{{subscription}}/resourceGroups/{{resourceGroup}}"
+    role: "Reader"
+    principal: "{{agentUamiPrincipalId}}"


### PR DESCRIPTION
## azuretoaws-sre-agent recipe

Connects Azure SRE Agent to AWS resources via the stdio MCP connector pattern. The agent spawns `mcp-proxy-for-aws` inside its container to handle SigV4 signing — no separate proxy hosting required.

### What's included

| Component | Purpose |
|-----------|---------|
| `connectors.json` | AWS MCP (stdio, SigV4) + AWS Knowledge MCP (remote, no auth) with `toolsVisibleToMetaAgent` and `selectedTools` set to `["*"]` |
| `config/skills/` | `investigate-aws-app-errors` — CloudWatch + Lambda + DynamoDB + X-Ray diagnostic playbook |
| `config/subagents/` | `aws-investigator` — autonomous subagent with `enableSkills: true` + `allowedSkills` |
| `config/hooks/` | `deny-aws-destructive` — blocks delete/terminate/stop without approval |
| `config/common-prompts/` | AWS-specific safety rules |
| `config/repos/` | GitHub repo connection for code context |
| `data/knowledge/` | AWS serverless architecture investigation guide |
| `connectors.secrets.env.example` | Template for AWS credentials |

### Tested with
- Deployed to `azuretoaws-sre-agent` in `rg-azuretoaws-sre-agent` (eastus2)
- Both connectors healthy + tools selected
- Skill, subagent, hook, common prompt, repo, knowledge all deployed successfully
- Agent successfully queried AWS Lambda functions and CloudWatch via the MCP connector

### Blog post
Accompanying blog: Cross-Cloud Operations: Using Azure SRE Agent to Manage AWS Apps (to be published on Tech Community)