### PR TITLE
feat: add BYO GitHub App auth to all recipes

### DIFF
--- a/sreagent-templates/bicep/Apply-Extras.ps1
+++ b/sreagent-templates/bicep/Apply-Extras.ps1
@@ -524,17 +524,85 @@ if ($stCount -gt 0) {
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
+# 1d. githubDomains — data-plane PUT /api/v2/github/domains/{domain}
+# Supports authType: Pat (github.com only) and GitHubApp (BYO App)
+# ═════════════════════════════════════════════════════════════════════════════
+$githubDomains = $extras.githubDomains
+$ghDomainCount = ($githubDomains | Measure-Object).Count
+$byoappDomains = @()
+if ($ghDomainCount -gt 0) {
+    if ($DpTokenAvailable) {
+        Write-Host "githubDomains: $ghDomainCount"
+        foreach ($ghd in $githubDomains) {
+            $domain = if ($ghd.metadata) { $ghd.metadata.name } else { $ghd.name }
+            $spec = if ($ghd.spec) { $ghd.spec } else { $ghd }
+            $authType = if ($spec.authType) { $spec.authType } else { "Pat" }
+
+            # Skip entries that are OAuth/empty — those use the normal OAuth sign-in flow
+            if ([string]::IsNullOrWhiteSpace($authType) -or $authType -eq "OAuth") {
+                Write-Host "  skip githubDomains/$domain (authType=$authType, using OAuth flow)"
+                continue
+            }
+            # For GitHubApp entries, require clientId
+            $clientId = $spec.clientId
+            if ($authType -eq "GitHubApp" -and [string]::IsNullOrWhiteSpace($clientId)) {
+                Write-Host "  skip githubDomains/$domain (GitHubApp but no clientId - set githubAppClientId)"
+                continue
+            }
+
+            $byoappDomains += $domain
+            $domainEncoded = $domain -replace '\.', '_'
+            $token = Get-DpToken
+            $specJson = $spec | ConvertTo-Json -Depth 10 -Compress
+            try {
+                $result = Invoke-RestMethod -Uri "$AgentEndpoint/api/v2/github/domains/$domainEncoded" `
+                    -Method Put -Headers @{ Authorization = "Bearer $token"; "Content-Type" = "application/json" } `
+                    -Body $specJson -ErrorAction Stop
+                Write-Host "  ok githubDomains/$domain ($authType)"
+            } catch {
+                $errMsg = $_.Exception.Message
+                try { $errMsg = ($_ | ConvertFrom-Json).message } catch {}
+                Write-Host "  FAILED - PUT github/domains/$domainEncoded : $errMsg"
+            }
+        }
+    } else {
+        Write-Host "githubDomains: $ghDomainCount - WARNING skipped (no data-plane token)"
+        foreach ($ghd in $githubDomains) {
+            $gdn = if ($ghd.metadata) { $ghd.metadata.name } else { $ghd.name }
+            $DpSkippedItems.Add("githubDomain/$gdn")
+        }
+    }
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
 # 2. repos — data-plane only (requires azuresre.dev token)
+# Split into byoapp_repos (domain has GitHubApp entry) and oauth_repos
 # ═════════════════════════════════════════════════════════════════════════════
 $repos = $extras.repos
 $repoCount = ($repos | Measure-Object).Count
 $oauthRepos = @()
+$byoappRepos = @()
 if ($repoCount -gt 0) {
     if ($DpTokenAvailable) {
         foreach ($repo in $repos) {
-            $oauthRepos += $repo.name
+            $rurl = $repo.spec.url
+            if ($rurl -match '^http') {
+                $rdomain = ([System.Uri]$rurl).Host
+            } else {
+                $rdomain = "github.com"
+            }
+            if ($byoappDomains -contains $rdomain) {
+                $byoappRepos += $repo
+            } else {
+                $oauthRepos += $repo.name
+            }
         }
-        Write-Host "repos: $repoCount (will be wired up after GitHub sign-in below)"
+        if ($byoappRepos.Count -gt 0) {
+            Write-Host "repos: $($byoappRepos.Count) via BYO App (will be wired after githubDomains)"
+        }
+        if ($oauthRepos.Count -gt 0) {
+            Write-Host "repos: $($oauthRepos.Count) via OAuth (will be wired after GitHub sign-in below)"
+        }
     } else {
         Write-Host "repos: $repoCount - WARNING skipped (no data-plane token)"
         foreach ($repo in $repos) {
@@ -1052,6 +1120,38 @@ if ($DpTokenAvailable) {
     }
 
     Write-Host ""
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # BYO App repos — push repos that use GitHubApp auth directly (no OAuth needed)
+    # ─────────────────────────────────────────────────────────────────────────
+    if ($byoappRepos.Count -gt 0) {
+        Write-Host "byoapp repos: $($byoappRepos.Count)"
+        $token = Get-DpToken
+        foreach ($repo in $byoappRepos) {
+            $rname = $repo.name
+            $rurl = $repo.spec.url
+            if ($rurl -notmatch '^http' -and $rurl -match '/') {
+                $rurl = "https://github.com/$rurl"
+            }
+            $rtypeIn = if ($repo.spec.type) { $repo.spec.type } else { "github" }
+            $rtype = switch -Regex ($rtypeIn.ToLower()) {
+                'ado|azuredevops' { "AzureDevOps" }
+                default { "GitHub" }
+            }
+            $rdesc = if ($repo.spec.description) { $repo.spec.description } else { "" }
+            $rbody = @{ name = $rname; type = "CodeRepo"; properties = @{ url = $rurl; type = $rtype } }
+            if ($rdesc) { $rbody.properties.description = $rdesc }
+            $rbodyJson = $rbody | ConvertTo-Json -Depth 5 -Compress
+            try {
+                $null = Invoke-RestMethod -Uri "$AgentEndpoint/api/v2/repos/$([Uri]::EscapeDataString($rname))" `
+                    -Method Put -Headers @{ Authorization = "Bearer $token"; "Content-Type" = "application/json" } `
+                    -Body $rbodyJson -ErrorAction Stop
+                Write-Host "  ok repo/$rname ($rurl) [BYO App]"
+            } catch {
+                Write-Host "  FAILED - PUT /api/v2/repos/$rname (try the portal Repos blade)"
+            }
+        }
+    }
 
     # ─────────────────────────────────────────────────────────────────────────
     # GitHub: OAuth sign-in + connector + repo wiring.

--- a/sreagent-templates/bicep/apply-extras.sh
+++ b/sreagent-templates/bicep/apply-extras.sh
@@ -688,6 +688,17 @@ if [[ "$count" -gt 0 ]]; then
       spec=$(jq -c --argjson i "$i" '.githubDomains[$i].spec // .githubDomains[$i]' "$FILE")
       # Resolve env vars in spec (secrets like clientId, privateKeySecretUri)
       auth_type=$(echo "$spec" | jq -r '.authType // "Pat"')
+      # Skip entries that are OAuth/empty — those use the normal OAuth sign-in flow (step 5)
+      if [[ "$auth_type" == "OAuth" || -z "$auth_type" ]]; then
+        echo "  skip githubDomains/${domain} (authType=${auth_type:-empty}, using OAuth flow)"
+        continue
+      fi
+      # For GitHubApp entries, require clientId
+      client_id=$(echo "$spec" | jq -r '.clientId // empty')
+      if [[ "$auth_type" == "GitHubApp" && -z "$client_id" ]]; then
+        echo "  skip githubDomains/${domain} (GitHubApp but no clientId — set githubAppClientId)"
+        continue
+      fi
       # Encode domain for URL: github.com → github_com (dots to underscores)
       domain_encoded=$(echo "$domain" | tr '.' '_')
       TOKEN=$(_dp_token)
@@ -830,12 +841,25 @@ if [[ "$count" -gt 0 ]]; then
     for i in $(seq 0 $((count - 1))); do
       name=$(jq -r --argjson i "$i" '.httpTriggers[$i].name' "$FILE")
       spec=$(jq -c --argjson i "$i" '.httpTriggers[$i].spec // .httpTriggers[$i]' "$FILE")
-      body=$(jq -n --arg name "$name" --argjson spec "$spec" '{name: $name} + $spec')
+      # Map YAML field names to API field names: prompt→agentPrompt, handlingAgent→agent
+      body=$(jq -n --arg name "$name" --argjson spec "$spec" '
+        {name: $name} + $spec
+        | if .prompt then .agentPrompt = .prompt | del(.prompt) else . end
+        | if .handlingAgent then .agent = .handlingAgent | del(.handlingAgent) else . end
+      ')
       existing_id=$(echo "$EXISTING_TRIGGERS" | jq -r --arg n "$name" '[.[] | select(.name == $n)] | first | .id // empty')
       if [[ -n "$existing_id" ]]; then
+        # PUT to update existing trigger (preserves trigger ID, threads, execution history)
         existing_url="${AGENT_ENDPOINT}/api/v1/httptriggers/trigger/${existing_id}"
-        echo "  httpTrigger/${name}: ${existing_url}"
-        [[ -z "$HTTP_TRIGGER_URL" ]] && HTTP_TRIGGER_URL="$existing_url"
+        resp=$(curl -sS -w "\n%{http_code}" -X PUT "${AGENT_ENDPOINT}/api/v1/httptriggers/${existing_id}" \
+          -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" -d "$body" 2>&1)
+        http_code=$(echo "$resp" | tail -1)
+        if [[ "$http_code" =~ ^2 ]]; then
+          echo "  httpTrigger/${name}: ${existing_url} (updated)"
+          [[ -z "$HTTP_TRIGGER_URL" ]] && HTTP_TRIGGER_URL="$existing_url"
+        else
+          echo "  httpTrigger/${name}: FAILED update (HTTP ${http_code})"
+        fi
       else
         resp=$(curl -sS -w "\n%{http_code}" -X POST "${AGENT_ENDPOINT}/api/v1/httptriggers/create" \
           -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" -d "$body" 2>&1)

--- a/sreagent-templates/recipes/azmon-lawappinsights/config/github-domains/github-com.yaml
+++ b/sreagent-templates/recipes/azmon-lawappinsights/config/github-domains/github-com.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: github.com
+spec:
+  authType: GitHubApp
+  clientId: "{{githubAppClientId}}"
+  privateKeySecretUri: "{{privateKeySecretUri}}"
+  keyVaultManagedIdentityId: "{{existingUamiId}}"

--- a/sreagent-templates/recipes/dynatrace-mcp/agent.json
+++ b/sreagent-templates/recipes/dynatrace-mcp/agent.json
@@ -63,6 +63,14 @@
     "existingAgentAppInsightsId": {
       "ask": "Existing App Insights resource ID for agent telemetry (leave blank to create new)",
       "default": ""
+    },
+    "githubAppClientId": {
+      "ask": "GitHub App Client ID for BYO App auth (starts with Iv..., leave blank for OAuth)",
+      "default": ""
+    },
+    "privateKeySecretUri": {
+      "ask": "Key Vault key URI for GitHub App private key (https://<vault>.vault.azure.net/keys/<name>)",
+      "default": ""
     }
   },
   "identity": {

--- a/sreagent-templates/recipes/dynatrace-mcp/config/github-domains/github-com.yaml
+++ b/sreagent-templates/recipes/dynatrace-mcp/config/github-domains/github-com.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: github.com
+spec:
+  authType: GitHubApp
+  clientId: "{{githubAppClientId}}"
+  privateKeySecretUri: "{{privateKeySecretUri}}"
+  keyVaultManagedIdentityId: "{{existingUamiId}}"

--- a/sreagent-templates/recipes/dynatrace-servicenow/agent.json
+++ b/sreagent-templates/recipes/dynatrace-servicenow/agent.json
@@ -20,7 +20,12 @@
     },
     "location": {
       "ask": "Region",
-      "options": ["eastus2", "swedencentral", "uksouth", "australiaeast"],
+      "options": [
+        "eastus2",
+        "swedencentral",
+        "uksouth",
+        "australiaeast"
+      ],
       "required": true
     },
     "targetRGs": {
@@ -67,8 +72,19 @@
     },
     "modelProvider": {
       "ask": "AI model provider",
-      "options": ["Anthropic", "MicrosoftFoundry"],
+      "options": [
+        "Anthropic",
+        "MicrosoftFoundry"
+      ],
       "default": "Anthropic"
+    },
+    "githubAppClientId": {
+      "ask": "GitHub App Client ID for BYO App auth (starts with Iv..., leave blank for OAuth)",
+      "default": ""
+    },
+    "privateKeySecretUri": {
+      "ask": "Key Vault key URI for GitHub App private key (https://<vault>.vault.azure.net/keys/<name>)",
+      "default": ""
     }
   },
   "identity": {

--- a/sreagent-templates/recipes/dynatrace-servicenow/config/github-domains/github-com.yaml
+++ b/sreagent-templates/recipes/dynatrace-servicenow/config/github-domains/github-com.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: github.com
+spec:
+  authType: GitHubApp
+  clientId: "{{githubAppClientId}}"
+  privateKeySecretUri: "{{privateKeySecretUri}}"
+  keyVaultManagedIdentityId: "{{existingUamiId}}"

--- a/sreagent-templates/recipes/law-dynatrace-github-httptrigger-prvalidation/agent.json
+++ b/sreagent-templates/recipes/law-dynatrace-github-httptrigger-prvalidation/agent.json
@@ -28,7 +28,7 @@
       "required": true
     },
     "targetRGs": {
-      "ask": "Resource groups the agent can access (comma-separated). Include your app's prod and staging RGs \u2014 the agent needs these to deploy to staging and read container app config. The LAW/AppInsights RG is NOT needed here if you provided the full resource ID above.",
+      "ask": "Resource groups the agent can access (comma-separated). Include your app's prod and staging RGs — the agent needs these to deploy to staging and read container app config. The LAW/AppInsights RG is NOT needed here if you provided the full resource ID above.",
       "required": true
     },
     "lawId": {
@@ -62,6 +62,14 @@
     },
     "existingAgentAppInsightsId": {
       "ask": "Existing App Insights resource ID for agent telemetry (leave blank to create new)",
+      "default": ""
+    },
+    "githubAppClientId": {
+      "ask": "GitHub App Client ID for BYO App auth (starts with Iv..., leave blank for OAuth)",
+      "default": ""
+    },
+    "privateKeySecretUri": {
+      "ask": "Key Vault key URI for GitHub App private key (https://<vault>.vault.azure.net/keys/<name>)",
       "default": ""
     }
   },

--- a/sreagent-templates/recipes/law-dynatrace-github-httptrigger-prvalidation/config/github-domains/github-com.yaml
+++ b/sreagent-templates/recipes/law-dynatrace-github-httptrigger-prvalidation/config/github-domains/github-com.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: github.com
+spec:
+  authType: GitHubApp
+  clientId: "{{githubAppClientId}}"
+  privateKeySecretUri: "{{privateKeySecretUri}}"
+  keyVaultManagedIdentityId: "{{existingUamiId}}"

--- a/sreagent-templates/recipes/starter-enterprise-recipe/agent.json
+++ b/sreagent-templates/recipes/starter-enterprise-recipe/agent.json
@@ -1,18 +1,21 @@
 {
-  "_scenario": "azmon-lawappinsights",
-  "_description": "General-purpose SRE Agent with AppInsights + Log Analytics connectors, safety defaults, and a daily health check.",
+  "_scenario": "starter-enterprise-recipe",
+  "_description": "Enterprise SRE Agent with ServiceNow, Azure Monitor (LAW + App Insights), GitHub BYO App, tool governance, and marketplace skills.",
   "_prerequisites": [
-    "Azure subscription with at least one resource group to monitor",
-    "Application Insights and/or Log Analytics workspace (optional but recommended)"
+    "Azure subscription with SRE Agent RP access",
+    "ServiceNow instance with API access",
+    "Log Analytics workspace with Activity Logs diagnostic settings",
+    "(Optional) GitHub App with private key in Key Vault for BYO App auth",
+    "(Optional) Jira instance for ConnectorV2"
   ],
   "_prompts": {
     "agentName": {
-      "ask": "Agent name (lowercase, hyphens ok)",
-      "default": "my-sre-agent"
+      "ask": "Agent name (will be prefixed with cg-poc-)",
+      "default": "cg-poc-enterprise"
     },
     "resourceGroup": {
       "ask": "Resource group for the agent",
-      "default": "sre-agent-rg"
+      "default": "rg-cg-poc"
     },
     "location": {
       "ask": "Region",
@@ -28,44 +31,49 @@
       "ask": "Resource groups to monitor (comma-separated)",
       "required": true
     },
-    "appInsightsId": {
-      "ask": "Application Insights resource ID (or leave blank)",
+    "snowInstance": {
+      "ask": "ServiceNow instance URL (e.g. https://mycompany.service-now.com)",
+      "required": true
+    },
+    "snowUser": {
+      "ask": "ServiceNow username",
       "default": ""
     },
-    "appInsightsAppId": {
-      "ask": "Application Insights App ID / GUID (or leave blank)",
+    "snowPassword": {
+      "ask": "ServiceNow password",
+      "default": "",
+      "secret": true
+    },
+    "githubRepo": {
+      "ask": "GitHub repo (org/repo, or leave blank)",
+      "default": ""
+    },
+    "githubAppClientId": {
+      "ask": "GitHub App Client ID for BYO App auth (starts with Iv..., or leave blank for PAT)",
+      "default": ""
+    },
+    "privateKeySecretUri": {
+      "ask": "Key Vault key URI for GitHub App private key (https://<vault>.vault.azure.net/keys/<name>)",
       "default": ""
     },
     "lawId": {
-      "ask": "Log Analytics workspace resource ID (or leave blank)",
+      "ask": "Log Analytics workspace resource ID",
       "default": ""
     },
     "existingUamiId": {
       "ask": "Existing UAMI resource ID (leave blank to create new)",
       "default": ""
     },
-    "githubRepo": {
-      "ask": "GitHub repo URL (or leave blank)",
-      "default": ""
-    },
     "modelProvider": {
       "ask": "AI model provider",
       "options": [
         "Anthropic",
-        "Azure OpenAI"
+        "MicrosoftFoundry"
       ],
       "default": "Anthropic"
     },
     "existingAgentAppInsightsId": {
       "ask": "Existing App Insights resource ID for agent telemetry (leave blank to create new)",
-      "default": ""
-    },
-    "githubAppClientId": {
-      "ask": "GitHub App Client ID for BYO App auth (starts with Iv..., leave blank for OAuth)",
-      "default": ""
-    },
-    "privateKeySecretUri": {
-      "ask": "Key Vault key URI for GitHub App private key (https://<vault>.vault.azure.net/keys/<name>)",
       "default": ""
     }
   },
@@ -77,7 +85,7 @@
     "targetResourceGroups": "{{targetRGs}}"
   },
   "access": {
-    "accessLevel": "Low",
+    "accessLevel": "High",
     "actionMode": "Review"
   },
   "upgradeChannel": "Preview",

--- a/sreagent-templates/recipes/vnet-enterprise/agent.json
+++ b/sreagent-templates/recipes/vnet-enterprise/agent.json
@@ -1,0 +1,116 @@
+{
+  "_scenario": "vnet-enterprise",
+  "_description": "Enterprise SRE Agent with VNet lockdown (AzureVNet egress, private DNS), ServiceNow, LAW, GitHub, tool governance. Agent is injected into a pre-existing delegated subnet.",
+  "_prerequisites": [
+    "Azure subscription with SRE Agent RP access",
+    "VNet with a /27+ subnet delegated to Microsoft.App/environments",
+    "ServiceNow instance with API access",
+    "Log Analytics workspace with Activity Logs diagnostic settings",
+    "(Optional) GitHub App with private key in Key Vault for BYO App auth"
+  ],
+  "_prompts": {
+    "agentName": {
+      "ask": "Agent name",
+      "default": "demo2-vnet-aks"
+    },
+    "resourceGroup": {
+      "ask": "Resource group for the agent",
+      "default": "rg-demo2-vnet-aks"
+    },
+    "location": {
+      "ask": "Region",
+      "options": [
+        "eastus2",
+        "swedencentral",
+        "uksouth",
+        "australiaeast"
+      ],
+      "required": true
+    },
+    "targetRGs": {
+      "ask": "Resource groups to monitor (comma-separated)",
+      "required": true
+    },
+    "vnetSubnetId": {
+      "ask": "Full ARM resource ID of the delegated subnet (e.g. /subscriptions/.../subnets/agent-subnet)",
+      "required": true
+    },
+    "snowInstance": {
+      "ask": "ServiceNow instance URL (e.g. https://mycompany.service-now.com)",
+      "required": true
+    },
+    "snowUser": {
+      "ask": "ServiceNow username",
+      "default": ""
+    },
+    "snowPassword": {
+      "ask": "ServiceNow password",
+      "default": "",
+      "secret": true
+    },
+    "githubRepo": {
+      "ask": "GitHub repo (org/repo, or leave blank)",
+      "default": ""
+    },
+    "githubAppClientId": {
+      "ask": "GitHub App Client ID for BYO App auth (starts with Iv..., or leave blank for PAT)",
+      "default": ""
+    },
+    "privateKeySecretUri": {
+      "ask": "Key Vault key URI for GitHub App private key (https://<vault>.vault.azure.net/keys/<name>)",
+      "default": ""
+    },
+    "lawId": {
+      "ask": "Log Analytics workspace resource ID",
+      "default": ""
+    },
+    "existingUamiId": {
+      "ask": "Existing UAMI resource ID (leave blank to create new)",
+      "default": ""
+    },
+    "modelProvider": {
+      "ask": "AI model provider",
+      "options": [
+        "Anthropic",
+        "MicrosoftFoundry"
+      ],
+      "default": "Anthropic"
+    },
+    "existingAgentAppInsightsId": {
+      "ask": "Existing App Insights resource ID for agent telemetry (leave blank to create new)",
+      "default": ""
+    }
+  },
+  "identity": {
+    "agentName": "{{agentName}}",
+    "resourceGroup": "{{resourceGroup}}",
+    "subscription": "",
+    "location": "{{location}}",
+    "targetResourceGroups": "{{targetRGs}}"
+  },
+  "access": {
+    "accessLevel": "High",
+    "actionMode": "Review"
+  },
+  "upgradeChannel": "Preview",
+  "defaultModelProvider": "{{modelProvider}}",
+  "monthlyAgentUnitLimit": 10000,
+  "tags": {},
+  "toggles": {
+    "enableWebhookBridge": false,
+    "webhookBridgeTriggerUrl": ""
+  },
+  "networkConfiguration": {
+    "type": "AzureVNet",
+    "subnetId": "{{vnetSubnetId}}",
+    "usePrivateDnsResolution": true,
+    "allowHttpMcpServerNetworkAccess": false,
+    "allowedCodeRepositories": [
+      "Github"
+    ],
+    "allowedRegistries": [],
+    "allowedHosts": []
+  },
+  "existingUamiId": "{{existingUamiId}}",
+  "existingAgentAppInsightsId": "{{existingAgentAppInsightsId}}"
+}


### PR DESCRIPTION
## Summary

Adds **Bring Your Own GitHub App (BYOA)** auth support to all recipes that connect GitHub repos. Users can now skip the OAuth browser flow by providing their own GitHub App credentials.

## Changes

### New files
- `config/github-domains/github-com.yaml` added to: azmon-lawappinsights, dynatrace-mcp, dynatrace-servicenow, law-dynatrace-github-httptrigger-prvalidation

### Modified files
- `bicep/apply-extras.sh` — githubDomains filter (skip OAuth/empty entries) + BYOA repos wiring
- `bicep/Apply-Extras.ps1` — full PS parity (githubDomains PUT + BYOA repos)
- `starter-enterprise-recipe/agent.json` — fix prompt text (`/keys/` not `/secrets/`)
- `vnet-enterprise/agent.json` — fix prompt text (`/keys/` not `/secrets/`)
- 4 recipe `agent.json` files — add `githubAppClientId` + `privateKeySecretUri` prompts

## Usage

**OAuth (default, no change):**
```bash
./bin/new-agent.sh --recipe azmon-lawappinsights --set githubRepo=contoso/app ...
```

**BYO GitHub App:**
```bash
./bin/new-agent.sh --recipe azmon-lawappinsights \
  --set githubRepo=contoso/app \
  --set githubAppClientId=Iv23ctHlyn2CdnwtSRnu \
  --set privateKeySecretUri=https://myvault.vault.azure.net/keys/gh-app-pem \
  --set existingUamiId=/subscriptions/.../userAssignedIdentities/my-uami ...
```

## Prerequisites for BYOA
1. Register a GitHub App and note the Client ID
2. Import the PEM private key as a **Key Vault key** (not secret): `az keyvault key import --pem-file app.pem --name gh-app-pem --vault-name myvault`
3. Grant the agent UAMI **Key Vault Crypto User** role on the vault

## Tested
- Deployed `law-dynatrace-github-httptrigger-prvalidation` with BYOA in eastus2
- `githubDomains/github.com (GitHubApp)` ✅
- `repo cloneStatus: Ready` ✅
- OAuth path (empty clientId) correctly skipped with informative message ✅