### PR TITLE
 Add VNet-integrated SRE Agent + private Key Vault Terraform example

### DIFF
--- a/sreagent-templates/examples/vnet-integrated-keyvault/.gitignore
+++ b/sreagent-templates/examples/vnet-integrated-keyvault/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+terraform.tfvars
+crash.log

--- a/sreagent-templates/examples/vnet-integrated-keyvault/README.md
+++ b/sreagent-templates/examples/vnet-integrated-keyvault/README.md
@@ -1,0 +1,110 @@
+# VNet-integrated SRE Agent with a private Key Vault
+
+Terraform example that deploys an Azure SRE Agent injected into a VNet, together
+with a Key Vault that has **public access disabled** and is reachable only over
+a **private endpoint**. Key Vault traffic - including during connector
+setup/validation - stays on the VNet and never traverses the public internet.
+
+Use this when you need the agent to read secrets or use keys (for example a
+GitHub App private key) from a locked-down Key Vault.
+
+## How the private path works
+
+The Key Vault FQDN must resolve to the **private endpoint IP** from inside the
+agent's VNet. That requires all four of these to line up - miss any one and the
+agent falls back to the vault's **public** IP, which a locked-down vault
+refuses:
+
+1. The agent is **VNet-injected** into a subnet delegated to
+   `Microsoft.App/environments` (`properties.vnetConfiguration.subnetResourceId`).
+2. The Key Vault has a **private endpoint** (`groupId = vault`) in that VNet.
+3. A **private DNS zone** `privatelink.vaultcore.azure.net` holds an A record
+   for the vault pointing at the private endpoint IP.
+4. That private DNS zone is **linked to the agent's VNet**.
+
+## What gets deployed
+
+| Resource | Setting that matters |
+|---|---|
+| VNet `sreagent-vnet` (`10.30.0.0/24`) | One VNet, two subnets |
+| ‣ `agent-subnet` (`10.30.0.0/27`) | Delegated to `Microsoft.App/environments` - agent injected here |
+| ‣ `pe-subnet` (`10.30.0.32/27`) | Holds the Key Vault private endpoint |
+| Key Vault | `public_network_access_enabled = false`, `default_action = Deny`, `bypass = None`, RBAC |
+| Private endpoint `pe-kv` | `subresource = vault`, in `pe-subnet` |
+| Private DNS zone `privatelink.vaultcore.azure.net` | A record → PE IP, linked to the VNet |
+| SRE Agent (`Microsoft.App/agents`) | `vnetConfiguration.subnetResourceId → agent-subnet` |
+| User-assigned identity | `Key Vault Crypto User` on the vault |
+
+This is a **single VNet with no Azure Firewall** - that is all that is required
+to reach a private-endpoint Key Vault. (A firewall / hub-and-spoke topology is a
+separate concern for controlling *outbound internet* egress and is not needed
+for the private Key Vault path.)
+
+## Deploy
+
+Prerequisites: `terraform` (or `tofu`) and `az login` into the target
+subscription.
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars: set subscription_id and a globally-unique key_vault_name
+
+terraform init
+terraform apply
+```
+
+## Validate the path is private
+
+From a shell **inside the agent sandbox** (or any VM on the VNet), resolve the
+vault FQDN:
+
+```bash
+nslookup <key_vault_name>.vault.azure.net
+```
+
+Expected - a **private** address via the `privatelink` CNAME:
+
+```
+<kv>.vault.azure.net  canonical name = <kv>.privatelink.vaultcore.azure.net
+Address: 10.30.0.36        <-- private endpoint IP (10.x). Correct.
+```
+
+- **`10.x` address** → private endpoint path. ✅
+- **Public IP** (`20.x`, `40.x`, `13.x`, …) → the FQDN is not using the private
+  DNS zone, and a locked-down vault will block it. Re-check items 1–4 above.
+
+## Verify the deployed configuration
+
+```bash
+SUB=<sub>; RG=<rg>; KV=<vault>; AGENT=<agent>
+
+# 1. Agent is VNet-injected - subnetResourceId must be set
+az rest --method GET \
+  --url "https://management.azure.com/subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.App/agents/$AGENT?api-version=2026-01-01" \
+  --query "properties.vnetConfiguration"
+
+# 2. Key Vault public access is disabled
+az keyvault show -g $RG -n $KV \
+  --query "{pub:properties.publicNetworkAccess, acls:properties.networkAcls}"
+
+# 3. Private endpoint exists, approved, groupId = vault
+az network private-endpoint list -g $RG \
+  --query "[].{name:name, status:privateLinkServiceConnections[0].privateLinkServiceConnectionState.status, group:privateLinkServiceConnections[0].groupIds}"
+
+# 4. Private DNS zone is linked to the agent's VNet (most common miss)
+az network private-dns link vnet list -g $RG -z privatelink.vaultcore.azure.net \
+  --query "[].{name:name, vnet:virtualNetwork.id}"
+
+# 5. A record points at the private endpoint IP
+az network private-dns record-set a list -g $RG -z privatelink.vaultcore.azure.net \
+  --query "[].{name:name, ips:aRecords[].ipv4Address}"
+```
+
+## Notes
+
+- **Region:** VNet injection is regional - the agent subnet must be in the same
+  region as the agent.
+- **Storing a GitHub App key:** import the `.pem` as a Key Vault **Key** (not a
+  secret) so it stays non-exportable; the agent identity (granted
+  `Key Vault Crypto User` here) uses the vault's sign operation. The deployer is
+  granted `Key Vault Crypto Officer` to perform the import.

--- a/sreagent-templates/examples/vnet-integrated-keyvault/main.tf
+++ b/sreagent-templates/examples/vnet-integrated-keyvault/main.tf
@@ -1,0 +1,192 @@
+########################################
+# VNet-integrated SRE Agent + private Key Vault
+#
+# The SRE Agent is injected into a delegated subnet, and a Key Vault with
+# public access disabled is reachable only through a private endpoint,
+# resolved via a private DNS zone linked to the same VNet. All Key Vault
+# traffic stays on the VNet.
+########################################
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  tenant_id   = var.tenant_id != "" ? var.tenant_id : data.azurerm_client_config.current.tenant_id
+  rg_name     = var.create_resource_group ? azurerm_resource_group.this[0].name : var.resource_group_name
+  rg_location = var.location
+}
+
+resource "azurerm_resource_group" "this" {
+  count    = var.create_resource_group ? 1 : 0
+  name     = var.resource_group_name
+  location = var.location
+}
+
+########################################
+# Networking: one VNet, two subnets
+########################################
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${var.name_prefix}-vnet"
+  location            = local.rg_location
+  resource_group_name = local.rg_name
+  address_space       = [var.vnet_address_space]
+}
+
+# Subnet the agent is injected into. Delegation to Microsoft.App/environments
+# is required for SRE Agent VNet injection.
+resource "azurerm_subnet" "agent" {
+  name                 = "agent-subnet"
+  resource_group_name  = local.rg_name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [var.agent_subnet_prefix]
+
+  delegation {
+    name = "app-env-delegation"
+    service_delegation {
+      name    = "Microsoft.App/environments"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# Subnet that holds the Key Vault private endpoint.
+resource "azurerm_subnet" "pe" {
+  name                 = "pe-subnet"
+  resource_group_name  = local.rg_name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [var.pe_subnet_prefix]
+}
+
+########################################
+# Managed identity for the agent
+########################################
+
+resource "azurerm_user_assigned_identity" "agent" {
+  name                = "${var.name_prefix}-identity"
+  location            = local.rg_location
+  resource_group_name = local.rg_name
+}
+
+########################################
+# Key Vault - public access disabled
+########################################
+
+resource "azurerm_key_vault" "kv" {
+  name                = var.key_vault_name
+  location            = local.rg_location
+  resource_group_name = local.rg_name
+  tenant_id           = local.tenant_id
+  sku_name            = "standard"
+
+  # RBAC authorization (not access policies).
+  rbac_authorization_enabled = true
+
+  # No public network access. The only way in is the private endpoint below.
+  public_network_access_enabled = false
+
+  network_acls {
+    default_action = "Deny"
+    bypass         = "None"
+  }
+}
+
+# Agent identity can use (sign with) keys in the vault. Crypto User is the
+# least privilege needed to use a GitHub App private key stored as a KV Key.
+resource "azurerm_role_assignment" "agent_crypto_user" {
+  scope                = azurerm_key_vault.kv.id
+  role_definition_name = "Key Vault Crypto User"
+  principal_id         = azurerm_user_assigned_identity.agent.principal_id
+}
+
+# The deployer can import the key (e.g. the GitHub App .pem as a KV Key).
+resource "azurerm_role_assignment" "deployer_crypto_officer" {
+  scope                = azurerm_key_vault.kv.id
+  role_definition_name = "Key Vault Crypto Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+########################################
+# Private endpoint + private DNS
+########################################
+
+resource "azurerm_private_dns_zone" "kv" {
+  name                = "privatelink.vaultcore.azure.net"
+  resource_group_name = local.rg_name
+}
+
+# Link the private DNS zone to the VNet. This makes <vault>.vault.azure.net
+# resolve to the private endpoint IP (10.x) from inside the agent's VNet.
+# Without this link the FQDN resolves to a public IP.
+resource "azurerm_private_dns_zone_virtual_network_link" "kv" {
+  name                  = "kv-dns-link"
+  resource_group_name   = local.rg_name
+  private_dns_zone_name = azurerm_private_dns_zone.kv.name
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+  registration_enabled  = false
+}
+
+resource "azurerm_private_endpoint" "kv" {
+  name                = "pe-kv"
+  location            = local.rg_location
+  resource_group_name = local.rg_name
+  subnet_id           = azurerm_subnet.pe.id
+
+  private_service_connection {
+    name                           = "pe-kv"
+    private_connection_resource_id = azurerm_key_vault.kv.id
+    subresource_names              = ["vault"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.kv.id]
+  }
+}
+
+########################################
+# SRE Agent (Microsoft.App/agents)
+# Deployed via azapi. The networking knob that matters is
+# properties.vnetConfiguration.subnetResourceId pointing at the
+# delegated agent subnet above.
+########################################
+
+resource "azapi_resource" "sre_agent" {
+  type      = "Microsoft.App/agents@2026-01-01"
+  name      = "${var.name_prefix}-agent"
+  location  = local.rg_location
+  parent_id = var.create_resource_group ? azurerm_resource_group.this[0].id : "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group_name}"
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.agent.id]
+  }
+
+  body = {
+    properties = {
+      # VNet injection: puts the agent (and its sandbox) on the VNet so it
+      # resolves and reaches Key Vault via the private endpoint.
+      vnetConfiguration = {
+        subnetResourceId = azurerm_subnet.agent.id
+      }
+
+      actionConfiguration = {
+        mode        = "review"
+        accessLevel = "Low"
+        identity    = azurerm_user_assigned_identity.agent.id
+      }
+
+      defaultModel = {
+        name     = "Automatic"
+        provider = "MicrosoftFoundry"
+      }
+    }
+  }
+
+  schema_validation_enabled = false
+
+  depends_on = [
+    azurerm_subnet.agent,
+    azurerm_private_dns_zone_virtual_network_link.kv,
+  ]
+}

--- a/sreagent-templates/examples/vnet-integrated-keyvault/outputs.tf
+++ b/sreagent-templates/examples/vnet-integrated-keyvault/outputs.tf
@@ -1,0 +1,41 @@
+output "resource_group" {
+  value = local.rg_name
+}
+
+output "vnet_id" {
+  value = azurerm_virtual_network.vnet.id
+}
+
+output "agent_subnet_id" {
+  description = "Delegated subnet the agent is injected into."
+  value       = azurerm_subnet.agent.id
+}
+
+output "pe_subnet_id" {
+  value = azurerm_subnet.pe.id
+}
+
+output "key_vault_id" {
+  value = azurerm_key_vault.kv.id
+}
+
+output "key_vault_uri" {
+  value = azurerm_key_vault.kv.vault_uri
+}
+
+output "private_endpoint_ip" {
+  description = "Private endpoint IP the vault FQDN should resolve to inside the VNet."
+  value       = azurerm_private_endpoint.kv.private_service_connection[0].private_ip_address
+}
+
+output "private_dns_zone_id" {
+  value = azurerm_private_dns_zone.kv.id
+}
+
+output "agent_id" {
+  value = azapi_resource.sre_agent.id
+}
+
+output "agent_identity_principal_id" {
+  value = azurerm_user_assigned_identity.agent.principal_id
+}

--- a/sreagent-templates/examples/vnet-integrated-keyvault/terraform.tfvars.example
+++ b/sreagent-templates/examples/vnet-integrated-keyvault/terraform.tfvars.example
@@ -1,0 +1,16 @@
+subscription_id       = "00000000-0000-0000-0000-000000000000"
+resource_group_name   = "sre-agent-vnet-kv"
+create_resource_group = true
+location              = "uksouth"
+name_prefix           = "sreagent"
+
+# Must be globally unique.
+key_vault_name = "my-sre-agent-kv"
+
+# Optional: pin the tenant. Leave empty to use your current az login context.
+# tenant_id = "00000000-0000-0000-0000-000000000000"
+
+# Address space (safe to leave as-is unless it collides with existing networks).
+vnet_address_space  = "10.30.0.0/24"
+agent_subnet_prefix = "10.30.0.0/27"
+pe_subnet_prefix    = "10.30.0.32/27"

--- a/sreagent-templates/examples/vnet-integrated-keyvault/variables.tf
+++ b/sreagent-templates/examples/vnet-integrated-keyvault/variables.tf
@@ -1,0 +1,59 @@
+variable "subscription_id" {
+  description = "Target Azure subscription ID."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group to deploy into. Created when create_resource_group = true."
+  type        = string
+  default     = "sre-agent-vnet-kv"
+}
+
+variable "create_resource_group" {
+  description = "Create the resource group (true) or use an existing one (false)."
+  type        = bool
+  default     = true
+}
+
+variable "location" {
+  description = "Azure region. The agent subnet must be in the same region as the agent (VNet injection is regional)."
+  type        = string
+  default     = "uksouth"
+}
+
+variable "name_prefix" {
+  description = "Prefix for resource names."
+  type        = string
+  default     = "sreagent"
+}
+
+variable "key_vault_name" {
+  description = "Globally-unique Key Vault name (3-24 chars, alphanumeric and hyphens)."
+  type        = string
+}
+
+variable "tenant_id" {
+  description = "AAD tenant ID for the Key Vault. Leave empty to use the current CLI context."
+  type        = string
+  default     = ""
+}
+
+# --- Address space ---
+
+variable "vnet_address_space" {
+  description = "VNet CIDR."
+  type        = string
+  default     = "10.30.0.0/24"
+}
+
+variable "agent_subnet_prefix" {
+  description = "Delegated subnet the SRE Agent is injected into (Microsoft.App/environments)."
+  type        = string
+  default     = "10.30.0.0/27"
+}
+
+variable "pe_subnet_prefix" {
+  description = "Subnet that holds the Key Vault private endpoint."
+  type        = string
+  default     = "10.30.0.32/27"
+}

--- a/sreagent-templates/examples/vnet-integrated-keyvault/versions.tf
+++ b/sreagent-templates/examples/vnet-integrated-keyvault/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+provider "azapi" {
+  subscription_id = var.subscription_id
+}


### PR DESCRIPTION
Adds a self-contained Terraform example that deploys a VNet-injected SRE Agent with a public-access-disabled Key Vault reachable only over a private endpoint (private DNS zone linked to the agent VNet).
Includes deploy steps, a sandbox nslookup check to prove the path stays private, and az commands to verify the config.