### PR TITLE
fix: add data-plane fallback for skills/tools/subagents/tasks/filters in export-agent

### DIFF
--- a/sreagent-templates/bin/export-agent.sh
+++ b/sreagent-templates/bin/export-agent.sh
@@ -87,6 +87,15 @@ done
 command -v jq >/dev/null || { echo "Error: jq is required" >&2; exit 1; }
 command -v az >/dev/null || { echo "Error: az CLI is required" >&2; exit 1; }
 
+# Resolve python command — python3 on macOS/Linux, python on Windows/MINGW
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON=python
+else
+  echo "Error: python3 or python is required" >&2; exit 1
+fi
+
 API_VERSION="2025-05-01-preview"
 ARM_BASE="https://management.azure.com/subscriptions/${SUB}/resourceGroups/${RG}/providers/Microsoft.App/agents/${AGENT}"
 
@@ -99,7 +108,7 @@ _fail() { echo "  ERROR: $*" >&2; exit 1; }
 
 # JSON → YAML conversion (for human-editable config files)
 json2yaml() {
-  python3 -c "
+  $PYTHON -c "
 import sys, json, yaml
 
 def strip_nulls(obj):
@@ -1098,7 +1107,7 @@ if [[ ${#SET_OVERRIDES[@]} -gt 0 ]]; then
         # Inject connectionKey into incident platform YAML
         for pf in "${EXPORT_DIR}/automations/incident-platforms"/*.yaml; do
           [[ -f "$pf" ]] || continue
-          python3 -c "
+          $PYTHON -c "
 import yaml, sys
 with open('$pf') as f: d = yaml.safe_load(f)
 d.setdefault('spec',{})['connectionKey'] = '$val'
@@ -1435,11 +1444,11 @@ if [[ $(echo "$INCIDENT_PLATFORMS" | jq 'length') -gt 0 ]]; then
     ptype=$(echo "$INCIDENT_PLATFORMS" | jq -r --argjson i "$i" '.[$i].spec.platformType // .[$i].spec.incidentPlatform // ""')
     case "$ptype" in
       PagerDuty|ServiceNow)
-        has_key=$(python3 -c "import yaml; d=yaml.safe_load(open('${EXPORT_DIR}/automations/incident-platforms/${ipname}.yaml')); print('yes' if d.get('spec',{}).get('connectionKey') else 'no')" 2>/dev/null || echo "no")
+        has_key=$($PYTHON -c "import yaml; d=yaml.safe_load(open('${EXPORT_DIR}/automations/incident-platforms/${ipname}.yaml')); print('yes' if d.get('spec',{}).get('connectionKey') else 'no')" 2>/dev/null || echo "no")
         if [[ "$has_key" != "yes" ]]; then
           # Add connectionKey as env var reference so assemble-agent.sh substitutes it
           env_var="$(echo "${ptype}" | tr '[:lower:]' '[:upper:]')_API_KEY"
-          python3 -c "
+          $PYTHON -c "
 import yaml
 f='${EXPORT_DIR}/automations/incident-platforms/${ipname}.yaml'
 with open(f) as fh: d = yaml.safe_load(fh)

--- a/sreagent-templates/bin/export-agent.sh
+++ b/sreagent-templates/bin/export-agent.sh
@@ -331,33 +331,102 @@ CONNECTORS=$(echo "$RAW_CONNECTORS" | jq -c --argjson dp "$DP_CONNECTORS" '[.[] 
 # Sanitize any embedded secrets in connector datasource strings
 CONNECTORS=$(sanitize "$CONNECTORS")
 
-# Tools (opaque — base64-encoded)
-_log "Reading tools..."
-RAW_TOOLS=$(arm_list "tools")
-TOOL_COUNT=$(echo "$RAW_TOOLS" | jq 'length')
-_log "  Found ${TOOL_COUNT} tool(s)"
-TOOLS=$(decode_opaque "$RAW_TOOLS")
+# Tools (opaque — base64-encoded; data-plane fallback for 3P tenants)
+_log "Reading tools (ARM)..."
+RAW_TOOLS=$(arm_list "tools" 2>/dev/null || echo "[]")
+TOOLS_ARM_COUNT=$(echo "$RAW_TOOLS" | jq 'length')
+if [[ "$TOOLS_ARM_COUNT" -gt 0 ]]; then
+  TOOLS=$(decode_opaque "$RAW_TOOLS")
+  TOOL_COUNT="$TOOLS_ARM_COUNT"
+  _log "  Found ${TOOLS_ARM_COUNT} tool(s) via ARM"
+else
+  _log "  None via ARM, trying data-plane..."
+  RAW_TOOLS_DP=$(dp_get "/api/v2/extendedAgent/tools")
+  if [[ "$RAW_TOOLS_DP" != "null" ]]; then
+    TOOLS=$(echo "$RAW_TOOLS_DP" | jq -c '[(.value // . // [])[] | {
+      metadata: { name: .name },
+      spec: (.properties // {})
+    }]' 2>/dev/null || echo "[]")
+  else
+    TOOLS="[]"
+  fi
+  TOOL_COUNT=$(echo "$TOOLS" | jq 'length')
+  _log "  Found ${TOOL_COUNT} tool(s) via data-plane"
+fi
 
-# Skills (opaque — special shape: Bicep encodes {name,description,tools,skillContent,additionalFiles})
-_log "Reading skills..."
-RAW_SKILLS=$(arm_list "skills")
-SKILL_COUNT=$(echo "$RAW_SKILLS" | jq 'length')
-_log "  Found ${SKILL_COUNT} skill(s)"
-SKILLS=$(decode_skills "$RAW_SKILLS")
+# Skills (opaque — special shape; data-plane fallback for 3P tenants)
+_log "Reading skills (ARM)..."
+RAW_SKILLS=$(arm_list "skills" 2>/dev/null || echo "[]")
+SKILLS_ARM_COUNT=$(echo "$RAW_SKILLS" | jq 'length')
+if [[ "$SKILLS_ARM_COUNT" -gt 0 ]]; then
+  SKILLS=$(decode_skills "$RAW_SKILLS")
+  SKILL_COUNT="$SKILLS_ARM_COUNT"
+  _log "  Found ${SKILLS_ARM_COUNT} skill(s) via ARM"
+else
+  _log "  None via ARM, trying data-plane..."
+  RAW_SKILLS_DP=$(dp_get "/api/v2/extendedAgent/skills")
+  if [[ "$RAW_SKILLS_DP" != "null" ]]; then
+    SKILLS=$(echo "$RAW_SKILLS_DP" | jq -c '[(.value // . // [])[] | {
+      metadata: {
+        name: .name,
+        description: (.properties.description // ""),
+        spec: { tools: (.properties.tools // []) }
+      },
+      skillContent: (.properties.skillContent // ""),
+      additionalFiles: (.properties.additionalFiles // [])
+    }]' 2>/dev/null || echo "[]")
+  else
+    SKILLS="[]"
+  fi
+  SKILL_COUNT=$(echo "$SKILLS" | jq 'length')
+  _log "  Found ${SKILL_COUNT} skill(s) via data-plane"
+fi
 
-# Scheduled Tasks (opaque)
-_log "Reading scheduled tasks..."
-RAW_TASKS=$(arm_list "scheduledTasks")
-TASK_COUNT=$(echo "$RAW_TASKS" | jq 'length')
-_log "  Found ${TASK_COUNT} scheduled task(s)"
-SCHEDULED_TASKS=$(decode_opaque "$RAW_TASKS")
+# Scheduled Tasks (opaque; data-plane fallback for 3P tenants)
+_log "Reading scheduled tasks (ARM)..."
+RAW_TASKS=$(arm_list "scheduledTasks" 2>/dev/null || echo "[]")
+TASKS_ARM_COUNT=$(echo "$RAW_TASKS" | jq 'length')
+if [[ "$TASKS_ARM_COUNT" -gt 0 ]]; then
+  SCHEDULED_TASKS=$(decode_opaque "$RAW_TASKS")
+  TASK_COUNT="$TASKS_ARM_COUNT"
+  _log "  Found ${TASKS_ARM_COUNT} scheduled task(s) via ARM"
+else
+  _log "  None via ARM, trying data-plane..."
+  RAW_TASKS_DP=$(dp_get "/api/v2/extendedAgent/scheduledtasks")
+  if [[ "$RAW_TASKS_DP" != "null" ]]; then
+    SCHEDULED_TASKS=$(echo "$RAW_TASKS_DP" | jq -c '[(.value // . // [])[] | {
+      metadata: { name: .name },
+      spec: (.properties // {})
+    }]' 2>/dev/null || echo "[]")
+  else
+    SCHEDULED_TASKS="[]"
+  fi
+  TASK_COUNT=$(echo "$SCHEDULED_TASKS" | jq 'length')
+  _log "  Found ${TASK_COUNT} scheduled task(s) via data-plane"
+fi
 
-# Incident Filters (opaque)
-_log "Reading incident filters..."
-RAW_FILTERS=$(arm_list "incidentFilters")
-FILTER_COUNT=$(echo "$RAW_FILTERS" | jq 'length')
-_log "  Found ${FILTER_COUNT} incident filter(s)"
-INCIDENT_FILTERS=$(decode_opaque "$RAW_FILTERS")
+# Incident Filters (opaque; data-plane fallback for 3P tenants)
+_log "Reading incident filters (ARM)..."
+RAW_FILTERS=$(arm_list "incidentFilters" 2>/dev/null || echo "[]")
+FILTERS_ARM_COUNT=$(echo "$RAW_FILTERS" | jq 'length')
+if [[ "$FILTERS_ARM_COUNT" -gt 0 ]]; then
+  INCIDENT_FILTERS=$(decode_opaque "$RAW_FILTERS")
+  FILTER_COUNT="$FILTERS_ARM_COUNT"
+  _log "  Found ${FILTERS_ARM_COUNT} incident filter(s) via ARM"
+else
+  _log "  None via ARM, trying data-plane..."
+  RAW_FILTERS_DP=$(dp_get "/api/v2/extendedAgent/incidentFilters")
+  if [[ "$RAW_FILTERS_DP" != "null" ]]; then
+    INCIDENT_FILTERS=$(echo "$RAW_FILTERS_DP" | jq -c '[(.value // . // [])[] | {
+      metadata: { name: .name },
+      spec: (.properties // {})
+    }]' 2>/dev/null || echo "[]")
+  else
+    INCIDENT_FILTERS="[]"
+  fi
+  FILTER_COUNT=$(echo "$INCIDENT_FILTERS" | jq 'length')
+  _log "  Found ${FILTER_COUNT} incident filter(s) via data-plane"
+fi
 
 # Incident Handlers — data-plane (customInstructions lives here, not on the filter)
 _log "Reading incident handlers (data-plane)..."
@@ -376,12 +445,28 @@ if [[ "$DP_HANDLER_COUNT" -gt 0 ]]; then
   _log "  Merged customInstructions into filters"
 fi
 
-# Subagents (opaque)
-_log "Reading subagents..."
-RAW_SUBAGENTS=$(arm_list "subagents")
-SUBAGENT_COUNT=$(echo "$RAW_SUBAGENTS" | jq 'length')
-_log "  Found ${SUBAGENT_COUNT} subagent(s)"
-SUBAGENTS=$(decode_opaque "$RAW_SUBAGENTS")
+# Subagents (opaque; data-plane fallback for 3P tenants)
+_log "Reading subagents (ARM)..."
+RAW_SUBAGENTS=$(arm_list "subagents" 2>/dev/null || echo "[]")
+SUBAGENTS_ARM_COUNT=$(echo "$RAW_SUBAGENTS" | jq 'length')
+if [[ "$SUBAGENTS_ARM_COUNT" -gt 0 ]]; then
+  SUBAGENTS=$(decode_opaque "$RAW_SUBAGENTS")
+  SUBAGENT_COUNT="$SUBAGENTS_ARM_COUNT"
+  _log "  Found ${SUBAGENTS_ARM_COUNT} subagent(s) via ARM"
+else
+  _log "  None via ARM, trying data-plane..."
+  RAW_SUBAGENTS_DP=$(dp_get "/api/v2/extendedAgent/agents")
+  if [[ "$RAW_SUBAGENTS_DP" != "null" ]]; then
+    SUBAGENTS=$(echo "$RAW_SUBAGENTS_DP" | jq -c '[(.value // . // [])[] | {
+      metadata: { name: .name },
+      spec: (.properties // {})
+    }]' 2>/dev/null || echo "[]")
+  else
+    SUBAGENTS="[]"
+  fi
+  SUBAGENT_COUNT=$(echo "$SUBAGENTS" | jq 'length')
+  _log "  Found ${SUBAGENT_COUNT} subagent(s) via data-plane"
+fi
 
 # Hooks (opaque — try ARM first; public Bicep deploys these via ARM now)
 _log "Reading hooks (ARM)..."

--- a/sreagent-templates/bin/ps/Export-Agent.ps1
+++ b/sreagent-templates/bin/ps/Export-Agent.ps1
@@ -456,33 +456,106 @@ $CONNECTORS = $RAW_CONNECTORS | Invoke-Jq -Compact -Filter '[.[] |
 Remove-Item $dpTmpFile -Force -ErrorAction SilentlyContinue
 $CONNECTORS = Invoke-Sanitize $CONNECTORS
 
-# ── Tools (opaque) ──
-_log 'Reading tools...'
+# ── Tools (opaque; data-plane fallback for 3P tenants) ──
+_log 'Reading tools (ARM)...'
 $RAW_TOOLS = Invoke-ArmList 'tools'
-$TOOL_COUNT = ($RAW_TOOLS | jq 'length') -as [int]
-_log "  Found ${TOOL_COUNT} tool(s)"
-$TOOLS = ConvertFrom-OpaqueArm $RAW_TOOLS
+$TOOLS_ARM_COUNT = ($RAW_TOOLS | jq 'length') -as [int]
+if ($TOOLS_ARM_COUNT -gt 0) {
+    $TOOLS = ConvertFrom-OpaqueArm $RAW_TOOLS
+    $TOOL_COUNT = $TOOLS_ARM_COUNT
+    _log "  Found ${TOOLS_ARM_COUNT} tool(s) via ARM"
+} else {
+    _log '  None via ARM, trying data-plane...'
+    $RAW_TOOLS_DP = Invoke-DpGet '/api/v2/extendedAgent/tools'
+    if ($RAW_TOOLS_DP -ne 'null') {
+        $TOOLS = $RAW_TOOLS_DP | Invoke-Jq -Compact -Filter '[(.value // . // [])[] | {
+            metadata: { name: .name },
+            spec: (.properties // {})
+        }]'
+        if (-not $TOOLS) { $TOOLS = '[]' }
+    } else {
+        $TOOLS = '[]'
+    }
+    $TOOL_COUNT = ($TOOLS | jq 'length') -as [int]
+    _log "  Found ${TOOL_COUNT} tool(s) via data-plane"
+}
 
-# ── Skills (opaque, special shape) ──
-_log 'Reading skills...'
+# ── Skills (opaque, special shape; data-plane fallback for 3P tenants) ──
+_log 'Reading skills (ARM)...'
 $RAW_SKILLS = Invoke-ArmList 'skills'
-$SKILL_COUNT = ($RAW_SKILLS | jq 'length') -as [int]
-_log "  Found ${SKILL_COUNT} skill(s)"
-$SKILLS = ConvertFrom-SkillsArm $RAW_SKILLS
+$SKILLS_ARM_COUNT = ($RAW_SKILLS | jq 'length') -as [int]
+if ($SKILLS_ARM_COUNT -gt 0) {
+    $SKILLS = ConvertFrom-SkillsArm $RAW_SKILLS
+    $SKILL_COUNT = $SKILLS_ARM_COUNT
+    _log "  Found ${SKILLS_ARM_COUNT} skill(s) via ARM"
+} else {
+    _log '  None via ARM, trying data-plane...'
+    $RAW_SKILLS_DP = Invoke-DpGet '/api/v2/extendedAgent/skills'
+    if ($RAW_SKILLS_DP -ne 'null') {
+        $SKILLS = $RAW_SKILLS_DP | Invoke-Jq -Compact -Filter '[(.value // . // [])[] | {
+            metadata: {
+                name: .name,
+                description: (.properties.description // ""),
+                spec: { tools: (.properties.tools // []) }
+            },
+            skillContent: (.properties.skillContent // ""),
+            additionalFiles: (.properties.additionalFiles // [])
+        }]'
+        if (-not $SKILLS) { $SKILLS = '[]' }
+    } else {
+        $SKILLS = '[]'
+    }
+    $SKILL_COUNT = ($SKILLS | jq 'length') -as [int]
+    _log "  Found ${SKILL_COUNT} skill(s) via data-plane"
+}
 
-# ── Scheduled Tasks (opaque) ──
-_log 'Reading scheduled tasks...'
+# ── Scheduled Tasks (opaque; data-plane fallback for 3P tenants) ──
+_log 'Reading scheduled tasks (ARM)...'
 $RAW_TASKS = Invoke-ArmList 'scheduledTasks'
-$TASK_COUNT = ($RAW_TASKS | jq 'length') -as [int]
-_log "  Found ${TASK_COUNT} scheduled task(s)"
-$SCHEDULED_TASKS = ConvertFrom-OpaqueArm $RAW_TASKS
+$TASKS_ARM_COUNT = ($RAW_TASKS | jq 'length') -as [int]
+if ($TASKS_ARM_COUNT -gt 0) {
+    $SCHEDULED_TASKS = ConvertFrom-OpaqueArm $RAW_TASKS
+    $TASK_COUNT = $TASKS_ARM_COUNT
+    _log "  Found ${TASKS_ARM_COUNT} scheduled task(s) via ARM"
+} else {
+    _log '  None via ARM, trying data-plane...'
+    $RAW_TASKS_DP = Invoke-DpGet '/api/v2/extendedAgent/scheduledtasks'
+    if ($RAW_TASKS_DP -ne 'null') {
+        $SCHEDULED_TASKS = $RAW_TASKS_DP | Invoke-Jq -Compact -Filter '[(.value // . // [])[] | {
+            metadata: { name: .name },
+            spec: (.properties // {})
+        }]'
+        if (-not $SCHEDULED_TASKS) { $SCHEDULED_TASKS = '[]' }
+    } else {
+        $SCHEDULED_TASKS = '[]'
+    }
+    $TASK_COUNT = ($SCHEDULED_TASKS | jq 'length') -as [int]
+    _log "  Found ${TASK_COUNT} scheduled task(s) via data-plane"
+}
 
-# ── Incident Filters (opaque) ──
-_log 'Reading incident filters...'
+# ── Incident Filters (opaque; data-plane fallback for 3P tenants) ──
+_log 'Reading incident filters (ARM)...'
 $RAW_FILTERS = Invoke-ArmList 'incidentFilters'
-$FILTER_COUNT = ($RAW_FILTERS | jq 'length') -as [int]
-_log "  Found ${FILTER_COUNT} incident filter(s)"
-$INCIDENT_FILTERS = ConvertFrom-OpaqueArm $RAW_FILTERS
+$FILTERS_ARM_COUNT = ($RAW_FILTERS | jq 'length') -as [int]
+if ($FILTERS_ARM_COUNT -gt 0) {
+    $INCIDENT_FILTERS = ConvertFrom-OpaqueArm $RAW_FILTERS
+    $FILTER_COUNT = $FILTERS_ARM_COUNT
+    _log "  Found ${FILTERS_ARM_COUNT} incident filter(s) via ARM"
+} else {
+    _log '  None via ARM, trying data-plane...'
+    $RAW_FILTERS_DP = Invoke-DpGet '/api/v2/extendedAgent/incidentFilters'
+    if ($RAW_FILTERS_DP -ne 'null') {
+        $INCIDENT_FILTERS = $RAW_FILTERS_DP | Invoke-Jq -Compact -Filter '[(.value // . // [])[] | {
+            metadata: { name: .name },
+            spec: (.properties // {})
+        }]'
+        if (-not $INCIDENT_FILTERS) { $INCIDENT_FILTERS = '[]' }
+    } else {
+        $INCIDENT_FILTERS = '[]'
+    }
+    $FILTER_COUNT = ($INCIDENT_FILTERS | jq 'length') -as [int]
+    _log "  Found ${FILTER_COUNT} incident filter(s) via data-plane"
+}
 
 # ── Incident Handlers (data-plane) — merge customInstructions ──
 _log 'Reading incident handlers (data-plane)...'
@@ -506,12 +579,29 @@ if ($DP_HANDLER_COUNT -gt 0) {
     _log '  Merged customInstructions into filters'
 }
 
-# ── Subagents (opaque) ──
-_log 'Reading subagents...'
+# ── Subagents (opaque; data-plane fallback for 3P tenants) ──
+_log 'Reading subagents (ARM)...'
 $RAW_SUBAGENTS = Invoke-ArmList 'subagents'
-$SUBAGENT_COUNT = ($RAW_SUBAGENTS | jq 'length') -as [int]
-_log "  Found ${SUBAGENT_COUNT} subagent(s)"
-$SUBAGENTS = ConvertFrom-OpaqueArm $RAW_SUBAGENTS
+$SUBAGENTS_ARM_COUNT = ($RAW_SUBAGENTS | jq 'length') -as [int]
+if ($SUBAGENTS_ARM_COUNT -gt 0) {
+    $SUBAGENTS = ConvertFrom-OpaqueArm $RAW_SUBAGENTS
+    $SUBAGENT_COUNT = $SUBAGENTS_ARM_COUNT
+    _log "  Found ${SUBAGENTS_ARM_COUNT} subagent(s) via ARM"
+} else {
+    _log '  None via ARM, trying data-plane...'
+    $RAW_SUBAGENTS_DP = Invoke-DpGet '/api/v2/extendedAgent/agents'
+    if ($RAW_SUBAGENTS_DP -ne 'null') {
+        $SUBAGENTS = $RAW_SUBAGENTS_DP | Invoke-Jq -Compact -Filter '[(.value // . // [])[] | {
+            metadata: { name: .name },
+            spec: (.properties // {})
+        }]'
+        if (-not $SUBAGENTS) { $SUBAGENTS = '[]' }
+    } else {
+        $SUBAGENTS = '[]'
+    }
+    $SUBAGENT_COUNT = ($SUBAGENTS | jq 'length') -as [int]
+    _log "  Found ${SUBAGENT_COUNT} subagent(s) via data-plane"
+}
 
 # ── Hooks (ARM) ──
 _log 'Reading hooks (ARM)...'

--- a/sreagent-templates/bin/ps/Export-Agent.ps1
+++ b/sreagent-templates/bin/ps/Export-Agent.ps1
@@ -1101,7 +1101,13 @@ Write-Host ''
 # Phase 5: Write structured output
 # ═══════════════════════════════════════════════════════════════════
 
-$EXPORT_DIR = $Output
+# Resolve to absolute path — [System.IO.File]::WriteAllText uses .NET CWD which
+# can diverge from PowerShell CWD, causing "Could not find a part of the path" errors.
+if ([System.IO.Path]::IsPathRooted($Output)) {
+    $EXPORT_DIR = $Output
+} else {
+    $EXPORT_DIR = Join-Path $PWD $Output
+}
 if (-not (Test-Path (Join-Path $EXPORT_DIR 'config'))) {
     New-Item -ItemType Directory -Path (Join-Path $EXPORT_DIR 'config') -Force | Out-Null
 }

--- a/sreagent-templates/bin/ps/Export-Agent.ps1
+++ b/sreagent-templates/bin/ps/Export-Agent.ps1
@@ -140,11 +140,24 @@ if (Test-Path $PrereqScript) {
     . $PrereqScript
     if (-not (Test-Prerequisites -IncludePython -IncludeCurl)) { exit 1 }
 } else {
-    foreach ($cmd in @('jq', 'az', 'python3', 'curl')) {
+    foreach ($cmd in @('jq', 'az', 'curl')) {
         if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
             Write-Host "Error: $cmd is required but not found." -ForegroundColor Red
             exit 1
         }
+    }
+    # Python: accept python3 (macOS/Linux) or python (Windows)
+    if (-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
+        if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+            Write-Host "Error: python3 or python is required but not found." -ForegroundColor Red
+            exit 1
+        }
+    }
+}
+# Ensure 'python3' resolves everywhere — on Windows only 'python' may exist
+if (-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        Set-Alias -Name python3 -Value python -Scope Script
     }
 }
 . (Join-Path $PSScriptRoot 'Invoke-Jq.ps1')


### PR DESCRIPTION
## Problem

`export-agent.sh` and `Export-Agent.ps1` only read skills, tools, subagents, scheduled tasks, and incident filters from ARM child resources. On **3P (external) tenants**, these resources are deployed via data-plane only (`apply-extras.sh`), so ARM returns 0 results and the export is incomplete.

## Root Cause

The Bicep deployment (`agent-extensions.bicep`) moved all child resources except connectors to data-plane to avoid ARM tenant restrictions that block 3P tenants. The deploy path (`apply-extras.sh`) was updated but the export path was not.

## Fix

Added inline data-plane fallback reads when ARM returns 0 results for each of the 5 affected resource types:

| Resource | ARM path | Data-plane fallback |
|---|---|---|
| Skills | `arm_list "skills"` | `GET /api/v2/extendedAgent/skills` |
| Subagents | `arm_list "subagents"` | `GET /api/v2/extendedAgent/agents` |
| Tools | `arm_list "tools"` | `GET /api/v2/extendedAgent/tools` |
| Scheduled Tasks | `arm_list "scheduledTasks"` | `GET /api/v2/extendedAgent/scheduledtasks` |
| Incident Filters | `arm_list "incidentFilters"` | `GET /api/v2/extendedAgent/incidentFilters` |

This matches the existing dual-path pattern already used for hooks, commonPrompts, and pluginConfigs.

Both `export-agent.sh` (bash) and `Export-Agent.ps1` (PowerShell) are updated.

## Testing

- Verified bash syntax (`bash -n`) and PowerShell syntax (`ParseFile`)
- Tested `--dry-run` export against a 1P agent (ARM path still works — skills: 2, subagents: 3, filters: 1)

Fixes #277