### PR TITLE
fix(zava): stop disabling built-in kubectl tools

### DIFF
--- a/labs/zava-aks-postgres/README.md
+++ b/labs/zava-aks-postgres/README.md
@@ -231,7 +231,7 @@ The Log Analytics workspace and Application Insights are scoped to an **Azure Mo
 
 This demo targets a permissive dev/sandbox subscription and works there as-is: it ships a Standard Azure Firewall with a public IP, a Basic ACR, AKS with local accounts enabled, and default public network access on the Log Analytics workspace / Application Insights (PostgreSQL is already VNet-integrated, with no public endpoint). A locked-down corporate landing zone with strict Azure Policy would likely require hardening those: `disableLocalAccounts` on AKS, a Premium ACR with a private endpoint, `publicNetworkAccess: 'Disabled'` on the workspace/App Insights, and a policy exemption for the firewall public IP. That hardened path isn't validated here.
 
-> **`disableLocalAccounts` and the SRE Agent.** On a hardened cluster the agent uses **native `kubectl`** authenticated by its own managed identity (`kubelogin convert-kubeconfig -l azurecli`) over a private network path to the API server (private-DNS link + firewall/SNAT). To keep the agent on that path, the lab removes the `RunKubectl*` tools from every skill and disables them agent-wide (`setup-sre-agent.ps1` Step 2c).
+> **`disableLocalAccounts` and the SRE Agent.** On a hardened cluster the agent can use **native `kubectl`** authenticated by its own managed identity (`kubelogin convert-kubeconfig -l azurecli`) over a private network path to the API server (private-DNS link + firewall/SNAT). The built-in `RunKubectl*` tools remain enabled as an additional supported Kubernetes execution path; `setup-sre-agent.ps1` Step 2c also repairs agents configured by older versions of the script that disabled those tools globally.
 
 ## Platform Behaviors
 

--- a/labs/zava-aks-postgres/README.md
+++ b/labs/zava-aks-postgres/README.md
@@ -231,7 +231,7 @@ The Log Analytics workspace and Application Insights are scoped to an **Azure Mo
 
 This demo targets a permissive dev/sandbox subscription and works there as-is: it ships a Standard Azure Firewall with a public IP, a Basic ACR, AKS with local accounts enabled, and default public network access on the Log Analytics workspace / Application Insights (PostgreSQL is already VNet-integrated, with no public endpoint). A locked-down corporate landing zone with strict Azure Policy would likely require hardening those: `disableLocalAccounts` on AKS, a Premium ACR with a private endpoint, `publicNetworkAccess: 'Disabled'` on the workspace/App Insights, and a policy exemption for the firewall public IP. That hardened path isn't validated here.
 
-> **`disableLocalAccounts` and the SRE Agent.** On a hardened cluster the agent can use **native `kubectl`** authenticated by its own managed identity (`kubelogin convert-kubeconfig -l azurecli`) over a private network path to the API server (private-DNS link + firewall/SNAT). The built-in `RunKubectl*` tools remain enabled as an additional supported Kubernetes execution path; `setup-sre-agent.ps1` Step 2c also repairs agents configured by older versions of the script that disabled those tools globally.
+> **`disableLocalAccounts` and the SRE Agent.** On a hardened cluster the agent can use **native `kubectl`** authenticated by its own managed identity (`kubelogin convert-kubeconfig -l azurecli`) over a private network path to the API server (private-DNS link + firewall/SNAT). This sample does not override the built-in `RunKubectl*` tool state.
 
 ## Platform Behaviors
 

--- a/labs/zava-aks-postgres/scripts/setup-sre-agent.ps1
+++ b/labs/zava-aks-postgres/scripts/setup-sre-agent.ps1
@@ -17,9 +17,6 @@
         and there is NO ARM/Bicep property for per-tool state (the agent's
         `permissions` stays null) — Microsoft's own `srectl tool config set` CLI
         exists for exactly this (POST /api/v2/agent/tools/configure).
-      - Global tool enablement: keep the built-in RunKubectl* tools ON for every
-        agent loop. This also reverses the agent-wide disablement applied by older
-        versions of this script.
       - Verification of Bicep-deployed assets
 .EXAMPLE
     .\scripts\setup-sre-agent.ps1
@@ -242,37 +239,6 @@ if ($present.Count -gt 0) {
     }
 }
 
-# --- Step 2c: Enable the built-in RunKubectl* tools globally (data-plane) ---
-# Older versions of this script disabled these tools agent-wide. Keep them
-# enabled so the agent can use the platform-provided Kubernetes tools as well as
-# native kubectl through RunInTerminal. The configure endpoint has merge
-# semantics, so this also repairs existing agents without resetting other tool
-# overrides.
-Write-Host "`nStep 2c: Enabling built-in RunKubectl* tools globally..." -ForegroundColor Yellow
-$kubectlCore = @('RunKubectlReadCommand', 'RunKubectlWriteCommand')
-$kcat = @()
-try {
-    $ktr = $client.GetAsync("$agentEndpoint/api/v2/agent/tools").Result
-    if ($ktr.IsSuccessStatusCode) { $kcat = @(($ktr.Content.ReadAsStringAsync().Result | ConvertFrom-Json).data) }
-} catch {}
-$kubeFromCat = @($kcat | Where-Object { $_.name -like 'RunKubectl*' } | ForEach-Object { $_.name })
-$kubectlTools = @($kubectlCore + $kubeFromCat | Select-Object -Unique)
-$kubePresent = @($kubectlTools | Where-Object { $_ -in $kcat.name })
-$kubeEnabled = @($kcat | Where-Object { ($_.name -in $kubectlTools) -and $_.enabled } | ForEach-Object { $_.name })
-if ($kubePresent.Count -gt 0 -and $kubePresent.Count -eq $kubectlTools.Count -and $kubeEnabled.Count -eq $kubectlTools.Count) {
-    Write-Host "  [skip] RunKubectl* tools already enabled globally ($($kubectlTools -join ', '))" -ForegroundColor DarkGray
-} else {
-    $kPayload = @{ overrides = @($kubectlTools | ForEach-Object { @{ name = $_; enabled = $true } }) } | ConvertTo-Json -Depth 4 -Compress
-    $kContent = [System.Net.Http.StringContent]::new($kPayload, [System.Text.Encoding]::UTF8, "application/json")
-    $kResp = $client.PostAsync("$agentEndpoint/api/v2/agent/tools/configure", $kContent).Result
-    if ($kResp.IsSuccessStatusCode) {
-        Write-Host "  [ok] Enabled built-in kubectl tools globally ($($kubectlTools -join ', '))" -ForegroundColor Green
-    } else {
-        Write-Host "  WARNING: kubectl tool enable returned $($kResp.StatusCode): $($kResp.Content.ReadAsStringAsync().Result)" -ForegroundColor Yellow
-    }
-    $kContent.Dispose()
-}
-
 # --- Step 3: Verify Bicep-deployed assets ----------------------------------
 Write-Host "`nStep 3: Verifying Bicep-deployed configuration..." -ForegroundColor Yellow
 $allGood = $true
@@ -344,13 +310,6 @@ if ($learnEnabled.Count -eq $learnTools.Count) {
     Write-Host "  [WARN] Learn MCP tools enabled globally: $($learnEnabled.Count)/$($learnTools.Count) (MCP connection may still be warming up)" -ForegroundColor Yellow; $allGood = $false
 }
 
-$kubeVerifyOn = @($vcat | Where-Object { ($_.name -in $kubectlTools) -and $_.enabled } | ForEach-Object { $_.name })
-if ($kubeVerifyOn.Count -eq $kubectlTools.Count) {
-    Write-Host "  [OK] Built-in RunKubectl* tools enabled globally: $($kubeVerifyOn.Count)/$($kubectlTools.Count)" -ForegroundColor Green
-} else {
-    Write-Host "  [WARN] RunKubectl* tools enabled globally: $($kubeVerifyOn.Count)/$($kubectlTools.Count) — re-run Step 2c to enable" -ForegroundColor Yellow; $allGood = $false
-}
-
 if ($allGood) { Write-Host "  All Bicep + data-plane assets verified." -ForegroundColor Green }
 else { Write-Host "  Some assets missing — see above." -ForegroundColor Yellow }
 
@@ -370,8 +329,6 @@ Write-Host "  [x] Response plans (incident filters): zava-database, zava-perform
 Write-Host "`n  DONE BY THIS SCRIPT (data plane — no ARM API yet):" -ForegroundColor Cyan
 Write-Host ("  [x] Knowledge files synced: {0} local file(s) ({1} uploaded, {2} replaced, {3} skipped, {4} failed)" -f $kbLocalFiles.Count, $uploaded, $replaced, $skipped, $failed)
 Write-Host ("  [x] Microsoft Learn MCP tools enabled globally: {0}/{1} (docs_search, code_sample_search, docs_fetch)" -f $learnEnabled.Count, $learnTools.Count)
-Write-Host ("  [x] Built-in RunKubectl* tools enabled globally: {0}/{1}" -f $kubeVerifyOn.Count, $kubectlTools.Count)
-
 Write-Host "`n  NEXT STEPS:" -ForegroundColor Cyan
 Write-Host "  Run a break scenario:"
 Write-Host "    .\.github\skills\running-demo\scripts\break-sql.ps1      # Stop PostgreSQL"

--- a/labs/zava-aks-postgres/scripts/setup-sre-agent.ps1
+++ b/labs/zava-aks-postgres/scripts/setup-sre-agent.ps1
@@ -17,11 +17,9 @@
         and there is NO ARM/Bicep property for per-tool state (the agent's
         `permissions` stays null) — Microsoft's own `srectl tool config set` CLI
         exists for exactly this (POST /api/v2/agent/tools/configure).
-      - Global tool DISABLEMENT: turn the built-in RunKubectl* tools OFF for every
-        agent loop. The lab is fully kube-native — the agent runs `kubectl` in its
-        sandbox terminal via managed-identity `kubelogin` — so these built-in tools
-        are disabled at the agent level via the same POST
-        /api/v2/agent/tools/configure API used to enable the Learn tools above.
+      - Global tool enablement: keep the built-in RunKubectl* tools ON for every
+        agent loop. This also reverses the agent-wide disablement applied by older
+        versions of this script.
       - Verification of Bicep-deployed assets
 .EXAMPLE
     .\scripts\setup-sre-agent.ps1
@@ -244,41 +242,33 @@ if ($present.Count -gt 0) {
     }
 }
 
-# --- Step 2c: Disable the built-in RunKubectl* tools globally (data-plane) --
-# This lab is fully kube-native: the agent runs `kubectl` itself in its sandbox
-# terminal (RunInTerminal), authenticated by its managed identity via `kubelogin`.
-# The built-in RunKubectl* tools are turned OFF at the agent level so the agent
-# uses that native path. This is the same POST /api/v2/agent/tools/configure API
-# Step 2b uses to enable the Learn tools, with a symmetric payload:
-# { overrides: [{ name, enabled: false }] }. We disable the two raw-kubectl tools
-# present in this agent's catalog (Read + Write) and union in any other tool whose
-# name starts with 'RunKubectl' the live catalog reports, so we never POST a name
-# the catalog can't confirm.
-Write-Host "`nStep 2c: Disabling built-in RunKubectl* tools globally (kube-native)..." -ForegroundColor Yellow
+# --- Step 2c: Enable the built-in RunKubectl* tools globally (data-plane) ---
+# Older versions of this script disabled these tools agent-wide. Keep them
+# enabled so the agent can use the platform-provided Kubernetes tools as well as
+# native kubectl through RunInTerminal. The configure endpoint has merge
+# semantics, so this also repairs existing agents without resetting other tool
+# overrides.
+Write-Host "`nStep 2c: Enabling built-in RunKubectl* tools globally..." -ForegroundColor Yellow
 $kubectlCore = @('RunKubectlReadCommand', 'RunKubectlWriteCommand')
 $kcat = @()
 try {
     $ktr = $client.GetAsync("$agentEndpoint/api/v2/agent/tools").Result
     if ($ktr.IsSuccessStatusCode) { $kcat = @(($ktr.Content.ReadAsStringAsync().Result | ConvertFrom-Json).data) }
 } catch {}
-# Always disable the two raw-kubectl tools; union in any other RunKubectl* the
-# live catalog actually reports so we never POST a name it can't confirm.
 $kubeFromCat = @($kcat | Where-Object { $_.name -like 'RunKubectl*' } | ForEach-Object { $_.name })
 $kubectlTools = @($kubectlCore + $kubeFromCat | Select-Object -Unique)
-# Built-in tools may not surface in the catalog readout, so skip only when the
-# catalog positively confirms every target is present AND already disabled.
 $kubePresent = @($kubectlTools | Where-Object { $_ -in $kcat.name })
-$kubeStillOn = @($kcat | Where-Object { ($_.name -in $kubectlTools) -and $_.enabled } | ForEach-Object { $_.name })
-if ($kubePresent.Count -gt 0 -and $kubePresent.Count -eq $kubectlTools.Count -and $kubeStillOn.Count -eq 0) {
-    Write-Host "  [skip] RunKubectl* tools already disabled globally ($($kubectlTools -join ', '))" -ForegroundColor DarkGray
+$kubeEnabled = @($kcat | Where-Object { ($_.name -in $kubectlTools) -and $_.enabled } | ForEach-Object { $_.name })
+if ($kubePresent.Count -gt 0 -and $kubePresent.Count -eq $kubectlTools.Count -and $kubeEnabled.Count -eq $kubectlTools.Count) {
+    Write-Host "  [skip] RunKubectl* tools already enabled globally ($($kubectlTools -join ', '))" -ForegroundColor DarkGray
 } else {
-    $kPayload = @{ overrides = @($kubectlTools | ForEach-Object { @{ name = $_; enabled = $false } }) } | ConvertTo-Json -Depth 4 -Compress
+    $kPayload = @{ overrides = @($kubectlTools | ForEach-Object { @{ name = $_; enabled = $true } }) } | ConvertTo-Json -Depth 4 -Compress
     $kContent = [System.Net.Http.StringContent]::new($kPayload, [System.Text.Encoding]::UTF8, "application/json")
     $kResp = $client.PostAsync("$agentEndpoint/api/v2/agent/tools/configure", $kContent).Result
     if ($kResp.IsSuccessStatusCode) {
-        Write-Host "  [ok] Disabled built-in kubectl tools globally ($($kubectlTools -join ', ')) — agent uses native kubectl via RunInTerminal" -ForegroundColor Green
+        Write-Host "  [ok] Enabled built-in kubectl tools globally ($($kubectlTools -join ', '))" -ForegroundColor Green
     } else {
-        Write-Host "  WARNING: kubectl tool disable returned $($kResp.StatusCode): $($kResp.Content.ReadAsStringAsync().Result)" -ForegroundColor Yellow
+        Write-Host "  WARNING: kubectl tool enable returned $($kResp.StatusCode): $($kResp.Content.ReadAsStringAsync().Result)" -ForegroundColor Yellow
     }
     $kContent.Dispose()
 }
@@ -355,10 +345,10 @@ if ($learnEnabled.Count -eq $learnTools.Count) {
 }
 
 $kubeVerifyOn = @($vcat | Where-Object { ($_.name -in $kubectlTools) -and $_.enabled } | ForEach-Object { $_.name })
-if ($kubeVerifyOn.Count -eq 0) {
-    Write-Host "  [OK] Built-in RunKubectl* tools disabled globally (agent is kube-native via RunInTerminal)" -ForegroundColor Green
+if ($kubeVerifyOn.Count -eq $kubectlTools.Count) {
+    Write-Host "  [OK] Built-in RunKubectl* tools enabled globally: $($kubeVerifyOn.Count)/$($kubectlTools.Count)" -ForegroundColor Green
 } else {
-    Write-Host "  [WARN] RunKubectl* still enabled: $($kubeVerifyOn -join ', ') — re-run Step 2c to disable" -ForegroundColor Yellow; $allGood = $false
+    Write-Host "  [WARN] RunKubectl* tools enabled globally: $($kubeVerifyOn.Count)/$($kubectlTools.Count) — re-run Step 2c to enable" -ForegroundColor Yellow; $allGood = $false
 }
 
 if ($allGood) { Write-Host "  All Bicep + data-plane assets verified." -ForegroundColor Green }
@@ -380,7 +370,7 @@ Write-Host "  [x] Response plans (incident filters): zava-database, zava-perform
 Write-Host "`n  DONE BY THIS SCRIPT (data plane — no ARM API yet):" -ForegroundColor Cyan
 Write-Host ("  [x] Knowledge files synced: {0} local file(s) ({1} uploaded, {2} replaced, {3} skipped, {4} failed)" -f $kbLocalFiles.Count, $uploaded, $replaced, $skipped, $failed)
 Write-Host ("  [x] Microsoft Learn MCP tools enabled globally: {0}/{1} (docs_search, code_sample_search, docs_fetch)" -f $learnEnabled.Count, $learnTools.Count)
-Write-Host ("  [x] Built-in RunKubectl* tools disabled globally: {0}/{1} (kube-native — agent runs kubectl in its sandbox terminal)" -f ($kubectlTools.Count - $kubeVerifyOn.Count), $kubectlTools.Count)
+Write-Host ("  [x] Built-in RunKubectl* tools enabled globally: {0}/{1}" -f $kubeVerifyOn.Count, $kubectlTools.Count)
 
 Write-Host "`n  NEXT STEPS:" -ForegroundColor Cyan
 Write-Host "  Run a break scenario:"


### PR DESCRIPTION
## Summary
- remove the agent-wide RunKubectl disablement from setup-sre-agent.ps1
- stop configuring or verifying built-in kubectl tool state
- document that the sample leaves the platform default unchanged

## Validation
- parsed setup-sre-agent.ps1 with the PowerShell AST parser
- ran git diff --check