### PR TITLE
fix: deploy knowledge items via data-plane instead of ARM connectors

### DIFF
--- a/sreagent-templates/bicep/Apply-Extras.ps1
+++ b/sreagent-templates/bicep/Apply-Extras.ps1
@@ -671,44 +671,67 @@ if ($kCount -gt 0) {
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
-# 4a-2. knowledgeItems — ARM PUT as KnowledgeFile connectors
+# 4a-2. knowledgeItems — data-plane PUT as KnowledgeItem connectors (Knowledge Sources)
 # ═════════════════════════════════════════════════════════════════════════════
 $knowledgeItems = $extras.knowledgeItems
 $kiCount = ($knowledgeItems | Measure-Object).Count
 if ($kiCount -gt 0) {
-    Write-Host "knowledgeItems: $kiCount file(s) -> Knowledge Sources (ARM)"
-    for ($i = 0; $i -lt $kiCount; $i++) {
-        $ki = $knowledgeItems[$i]
-        $fname = $ki.name
-        $content = $ki.content
-        if ([string]::IsNullOrEmpty($content)) {
-            Write-Host "  skip $fname (no content)"
-            continue
-        }
-        $sanitized = ($fname.ToLower() -replace '[^a-z0-9-]', '-') -replace '-+', '-' -replace '^-|-$', ''
-        $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($content))
-        $ctype = switch -Regex ($fname) {
-            '\.md$'   { "text/markdown" }
-            '\.txt$'  { "text/plain" }
-            '\.pdf$'  { "application/pdf" }
-            '\.json$' { "application/json" }
-            default   { "application/octet-stream" }
-        }
-        $body = @{
-            properties = @{
-                dataConnectorType  = "KnowledgeFile"
-                dataSource         = $sanitized
-                extendedProperties = @{
-                    displayName = $fname
-                    fileName    = $fname
-                    fileContent = $b64
-                    contentType = $ctype
-                }
+    if ($dpTokenAvailable) {
+        Write-Host "knowledgeItems: $kiCount file(s) -> Knowledge Sources (data-plane)"
+        for ($i = 0; $i -lt $kiCount; $i++) {
+            $ki = $knowledgeItems[$i]
+            $fname = $ki.name
+            $content = $ki.content
+            if ([string]::IsNullOrEmpty($content)) {
+                Write-Host "  skip $fname (no content)"
+                continue
             }
-        } | ConvertTo-Json -Compress -Depth 10
-        Arm-PutConnector -Name $sanitized -BodyJson $body
-        # KnowledgeFile connectors need 15s between PUTs to avoid 500s
-        if ($i -lt ($kiCount - 1)) { Start-Sleep -Seconds 15 }
+            $sanitized = ($fname.ToLower() -replace '[^a-z0-9-]', '-') -replace '-+', '-' -replace '^-|-$', ''
+            $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($content))
+            $ctype = switch -Regex ($fname) {
+                '\.md$'   { "text/markdown" }
+                '\.txt$'  { "text/plain" }
+                '\.pdf$'  { "application/pdf" }
+                '\.json$' { "application/json" }
+                default   { "application/octet-stream" }
+            }
+            $body = @{
+                name       = $sanitized
+                type       = "KnowledgeItem"
+                tags       = @()
+                properties = @{
+                    dataConnectorType  = "KnowledgeFile"
+                    dataSource         = $sanitized
+                    extendedProperties = @{
+                        displayName = $fname
+                        fileName    = $fname
+                        fileContent = $b64
+                        contentType = $ctype
+                    }
+                }
+            } | ConvertTo-Json -Compress -Depth 10
+            $token = Get-DpToken
+            $url = "${AgentEndpoint}/api/v2/extendedAgent/connectors/$([Uri]::EscapeDataString($sanitized))"
+            try {
+                $result = curl -sS -w "`n%{http_code}" -X PUT $url `
+                    -H "Authorization: Bearer $token" `
+                    -H "Content-Type: application/json" `
+                    --data $body 2>$null
+                $lines = $result -split "`n"
+                $httpCode = $lines[-1]
+                if ($httpCode -match '^2') {
+                    Write-Host "  ok knowledgeItems/$sanitized"
+                } else {
+                    Write-Host "  FAILED - PUT knowledgeItems/$sanitized (HTTP $httpCode)"
+                }
+            } catch {
+                Write-Host "  FAILED - PUT knowledgeItems/$sanitized (exception)"
+            }
+            if ($i -lt ($kiCount - 1)) { Start-Sleep -Seconds 5 }
+        }
+    } else {
+        Write-Host "knowledgeItems: $kiCount - skipped (no data-plane token)"
+        $dpSkippedItems += "knowledgeItems ($kiCount files)"
     }
 }
 

--- a/sreagent-templates/bicep/Assemble-Agent.ps1
+++ b/sreagent-templates/bicep/Assemble-Agent.ps1
@@ -404,7 +404,8 @@ if (Test-Path (Join-Path $dataDir 'repo-instructions.json') -PathType Leaf) {
     $repoInstructions = Get-Content (Join-Path $dataDir 'repo-instructions.json') -Raw
 }
 
-# Auto-discover .md files in data/ and data/knowledge/ → convert to knowledge items for upload
+# Auto-discover .md files in data/, data/knowledge/, data/session-insights/ → knowledgeItems
+# Session insights from a prior agent are made available as knowledge items on the new agent.
 $mdFiles = @()
 if (Test-Path $dataDir -PathType Container) {
     $mdFiles += Get-ChildItem $dataDir -Filter '*.md' -File -ErrorAction SilentlyContinue
@@ -412,6 +413,10 @@ if (Test-Path $dataDir -PathType Container) {
 $knowledgeSubdir = Join-Path $dataDir 'knowledge'
 if (Test-Path $knowledgeSubdir -PathType Container) {
     $mdFiles += Get-ChildItem $knowledgeSubdir -Filter '*.md' -File -ErrorAction SilentlyContinue
+}
+$insightsSubdir = Join-Path $dataDir 'session-insights'
+if (Test-Path $insightsSubdir -PathType Container) {
+    $mdFiles += Get-ChildItem $insightsSubdir -Filter '*.md' -File -ErrorAction SilentlyContinue
 }
 
 if ($mdFiles.Count -gt 0) {
@@ -575,11 +580,11 @@ $hooksArm = @($hooksArr | ForEach-Object {
 })
 
 # commonPrompts already transformed above ($commonPromptsArm)
-# Filter: connectors going into extras = only Mcp or KnowledgeFile types
+# Filter: connectors going into extras = only Mcp types (KnowledgeFile uses knowledgeItems path)
 $extrasConnectors = @($connectorsArr | Where-Object {
     $t = ''
     if ($null -ne $_) { $t = (Get-Prop (Get-Prop $_ 'properties') 'dataConnectorType' '') }
-    $t -eq 'Mcp' -or $t -eq 'KnowledgeFile'
+    $t -eq 'Mcp'
 })
 
 $extrasObj = [ordered]@{

--- a/sreagent-templates/bicep/apply-extras.sh
+++ b/sreagent-templates/bicep/apply-extras.sh
@@ -497,45 +497,62 @@ if [[ "$count" -gt 0 ]]; then
   fi
 fi
 
-# 4a-2. knowledgeItems — ARM PUT as KnowledgeFile connectors (visible in portal Knowledge Sources)
+# 4a-2. knowledgeItems — data-plane PUT as KnowledgeItem connectors (Knowledge Sources)
 count=$(jq '.knowledgeItems // [] | length' "$FILE")
 if [[ "$count" -gt 0 ]]; then
-  echo "knowledgeItems: ${count} file(s) → Knowledge Sources (ARM)"
-  for i in $(seq 0 $((count - 1))); do
-    fname=$(jq -r --argjson i "$i" '.knowledgeItems[$i].name' "$FILE")
-    content=$(jq -r --argjson i "$i" '.knowledgeItems[$i].content' "$FILE")
-    content_length=${#content}
-    sanitized=$(echo "$fname" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
-    b64=$(echo "$content" | base64)
-    case "$fname" in
-      *.md)   ctype="text/markdown" ;;
-      *.txt)  ctype="text/plain" ;;
-      *.pdf)  ctype="application/pdf" ;;
-      *.json) ctype="application/json" ;;
-      *)      ctype="application/octet-stream" ;;
-    esac
-    body=$(jq -nc \
-      --arg name "$sanitized" \
-      --arg displayName "$fname" \
-      --arg fileName "$fname" \
-      --arg fileContent "$b64" \
-      --arg contentType "$ctype" \
-      '{
-        properties: {
-          dataConnectorType: "KnowledgeFile",
-          dataSource: $name,
-          extendedProperties: {
-            displayName: $displayName,
-            fileName: $fileName,
-            fileContent: $fileContent,
-            contentType: $contentType
+  if [[ "$DP_TOKEN_AVAILABLE" == "true" ]]; then
+    echo "knowledgeItems: ${count} file(s) → Knowledge Sources (data-plane)"
+    for i in $(seq 0 $((count - 1))); do
+      fname=$(jq -r --argjson i "$i" '.knowledgeItems[$i].name' "$FILE")
+      content=$(jq -r --argjson i "$i" '.knowledgeItems[$i].content' "$FILE")
+      sanitized=$(echo "$fname" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+      b64=$(echo "$content" | base64)
+      case "$fname" in
+        *.md)   ctype="text/markdown" ;;
+        *.txt)  ctype="text/plain" ;;
+        *.pdf)  ctype="application/pdf" ;;
+        *.json) ctype="application/json" ;;
+        *)      ctype="application/octet-stream" ;;
+      esac
+      body=$(jq -nc \
+        --arg name "$sanitized" \
+        --arg displayName "$fname" \
+        --arg fileName "$fname" \
+        --arg fileContent "$b64" \
+        --arg contentType "$ctype" \
+        '{
+          name: $name,
+          type: "KnowledgeItem",
+          tags: [],
+          properties: {
+            dataConnectorType: "KnowledgeFile",
+            dataSource: $name,
+            extendedProperties: {
+              displayName: $displayName,
+              fileName: $fileName,
+              fileContent: $fileContent,
+              contentType: $contentType
+            }
           }
-        }
-      }')
-    arm_put_connector "$sanitized" "$body"
-    # KnowledgeFile connectors need 15s between PUTs to avoid 500s
-    [[ $i -lt $((count - 1)) ]] && sleep 15
-  done
+        }')
+      TOKEN=$(_dp_token)
+      url="${AGENT_ENDPOINT}/api/v2/extendedAgent/connectors/$(printf %s "$sanitized" | jq -sRr @uri)"
+      result=$(curl -sS -w "\n%{http_code}" -X PUT "$url" \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        --data "$body" 2>&1)
+      http_code=$(echo "$result" | tail -1)
+      if [[ "$http_code" =~ ^2 ]]; then
+        echo "  ok knowledgeItems/${sanitized}"
+      else
+        echo "  FAILED — PUT knowledgeItems/${sanitized} (HTTP ${http_code})"
+      fi
+      [[ $i -lt $((count - 1)) ]] && sleep 5
+    done
+  else
+    echo "knowledgeItems: ${count} — ⚠ skipped (no data-plane token)"
+    DP_SKIPPED_ITEMS+=("knowledgeItems (${count} files)")
+  fi
 fi
 
 # 4a-3. synthesizedKnowledge — tar.gz upload to WorkspaceMemory (data-plane)

--- a/sreagent-templates/bicep/assemble-agent.sh
+++ b/sreagent-templates/bicep/assemble-agent.sh
@@ -301,18 +301,20 @@ fi
 REPO_INSTRUCTIONS="[]"
 [[ -f "${DIR}/data/repo-instructions.json" ]] && REPO_INSTRUCTIONS=$(cat "${DIR}/data/repo-instructions.json")
 
-# Auto-discover .md files in data/ and data/knowledge/ → upload via AgentMemory (data-plane)
-# These show in the portal Knowledge tab (RAG-indexed), NOT as KnowledgeFile connectors.
+# Auto-discover .md files in data/, data/knowledge/, data/session-insights/ → knowledgeItems
+# Deployed via data-plane PUT /api/v2/extendedAgent/connectors/{name} as KnowledgeItem.
+# Session insights from a prior agent are made available as knowledge items on the new agent.
 MD_FILES=$(find "${DIR}/data" -maxdepth 1 -name "*.md" -type f 2>/dev/null || true; \
-           find "${DIR}/data/knowledge" -maxdepth 1 -name "*.md" -type f 2>/dev/null || true)
+           find "${DIR}/data/knowledge" -maxdepth 1 -name "*.md" -type f 2>/dev/null || true; \
+           find "${DIR}/data/session-insights" -maxdepth 1 -name "*.md" -type f 2>/dev/null || true)
 if [[ -n "$MD_FILES" ]]; then
   MD_COUNT=$(echo "$MD_FILES" | wc -l | tr -d ' ')
   _log "Found ${MD_COUNT} knowledge .md file(s) in data/"
   for mdf in $MD_FILES; do
     fname=$(basename "$mdf")
-    abs_path=$(cd "$(dirname "$mdf")" && pwd)/$(basename "$mdf")
-    KNOWLEDGE=$(echo "$KNOWLEDGE" | jq --arg fname "$fname" --arg path "$abs_path" \
-      '. + [{"filename": $fname, "mimeType": "text/markdown", "triggerIndexing": true, "localPath": $path}]')
+    content=$(cat "$mdf")
+    KNOWLEDGE_ITEMS=$(echo "$KNOWLEDGE_ITEMS" | jq --arg name "$fname" --arg content "$content" \
+      '. + [{"name": $name, "type": "KnowledgeText", "content": $content}]')
   done
 fi
 
@@ -444,7 +446,7 @@ jq -n \
       "marketplaces": $marketplaces,
       "installations": $installations
     },
-    "connectors": [$connectors[] | select(.properties.dataConnectorType == "Mcp" or .properties.dataConnectorType == "KnowledgeFile")],
+    "connectors": [$connectors[] | select(.properties.dataConnectorType == "Mcp")],
     "skills": $skills,
     "subagents": $subagents,
     "tools": $tools,

--- a/sreagent-templates/bin/export-agent.sh
+++ b/sreagent-templates/bin/export-agent.sh
@@ -670,9 +670,8 @@ else
 fi
 
 # ── 2. Knowledge items (KnowledgeText/File/WebPage/Repository via connectors API) ──
-# NOTE: KnowledgeText items are exported as plain .md files in data/ so that
-# on re-deploy they go through the AgentMemory data-plane upload (Knowledge tab)
-# instead of being re-created as ARM KnowledgeFile connectors.
+# Knowledge items are preserved as-is and redeployed via data-plane connector PUT
+# (not converted to AgentMemory .md uploads) so they appear under Knowledge Sources.
 if [[ "$INCLUDE_KNOWLEDGE_ITEMS" == "true" ]]; then
   _log "Reading knowledge items from connectors API..."
   RAW_KNOWLEDGE_ITEMS=$(dp_get "/api/v2/extendedAgent/connectors")
@@ -682,62 +681,37 @@ if [[ "$INCLUDE_KNOWLEDGE_ITEMS" == "true" ]]; then
       select(.properties.dataConnectorType // "" | test("^Knowledge")) |
       {
         name: .name,
-        type: .properties.dataConnectorType,
-        displayName: (.properties.displayName // .name),
+        type: (.type // "KnowledgeItem"),
+        dataConnectorType: .properties.dataConnectorType,
+        displayName: (.properties.displayName // .properties.extendedProperties.displayName // .name),
         sourceUrl: (.properties.sourceUrl // ""),
-        metadata: (.properties.metadata // {}),
-        fileSize: (.properties.fileSize // 0)
+        properties: .properties
       }
     ]' 2>/dev/null || echo "[]")
   fi
   KI_COUNT=$(echo "$KNOWLEDGE_ITEMS" | jq 'length')
   _log "  Found ${KI_COUNT} knowledge item(s)"
 
-  # Download knowledge item content and write KnowledgeText as .md in data/
+  # Download content for knowledge items if requested
   if [[ "$DOWNLOAD_FILES" == "true" && "$KI_COUNT" -gt 0 ]]; then
     _log "  Downloading knowledge item content..."
     KI_DIR="${FILES_DIR}/knowledge-items"
     mkdir -p "$KI_DIR"
-    KI_TEXT_EXPORTED=0
-    KI_OTHER_ITEMS="[]"
     for i in $(seq 0 $((KI_COUNT - 1))); do
       kiname=$(echo "$KNOWLEDGE_ITEMS" | jq -r --argjson i "$i" '.[$i].name')
-      kitype=$(echo "$KNOWLEDGE_ITEMS" | jq -r --argjson i "$i" '.[$i].type')
+      kitype=$(echo "$KNOWLEDGE_ITEMS" | jq -r --argjson i "$i" '.[$i].dataConnectorType')
+      ext=""
       case "$kitype" in
-        KnowledgeText)
-          # Export as .md file in data/ → will be uploaded via AgentMemory on redeploy
-          fname="${kiname}.md"
-          # Try to strip trailing -md suffix from connector name for cleaner filenames
-          [[ "$kiname" == *-md ]] && fname="${kiname%-md}.md"
-          dp_download "/api/v2/extendedAgent/connectors/$(printf %s "$kiname" | jq -sRr @uri)/content" \
-            "${KI_DIR}/${fname}" 2>/dev/null && {
-            _log "    ✓ ${kiname} → data/${fname} (will use AgentMemory on redeploy)"
-            KI_TEXT_EXPORTED=$((KI_TEXT_EXPORTED + 1))
-          } || _log "    ✗ ${kiname} (could not download content)"
-          ;;
-        *)
-          # Non-text items (WebPage, File, Repository) stay as knowledgeItems
-          ext=""
-          case "$kitype" in
-            KnowledgeWebPage) ext=".html" ;;
-            KnowledgeFile)    ext="" ;;
-            *)                ext=".json" ;;
-          esac
-          dp_download "/api/v2/extendedAgent/connectors/$(printf %s "$kiname" | jq -sRr @uri)/content" \
-            "${KI_DIR}/${kiname}${ext}" 2>/dev/null && \
-            _log "    ✓ ${kiname} (${kitype})" || \
-            _log "    ✗ ${kiname} (could not download content)"
-          KI_OTHER_ITEMS=$(echo "$KI_OTHER_ITEMS" | jq --argjson i "$i" --arg dir "$KI_DIR" --arg ext "$ext" \
-            --slurpfile items <(echo "$KNOWLEDGE_ITEMS") \
-            '. + [$items[0][$i] + {localPath: ($dir + "/" + $items[0][$i].name + $ext)}]')
-          ;;
+        KnowledgeText)    ext=".md" ;;
+        KnowledgeWebPage) ext=".html" ;;
+        KnowledgeFile)    ext="" ;;
+        *)                ext=".json" ;;
       esac
+      dp_download "/api/v2/extendedAgent/connectors/$(printf %s "$kiname" | jq -sRr @uri)/content" \
+        "${KI_DIR}/${kiname}${ext}" 2>/dev/null && \
+        _log "    ✓ ${kiname} (${kitype})" || \
+        _log "    ✗ ${kiname} (could not download content)"
     done
-    # Only keep non-text items in KNOWLEDGE_ITEMS (text ones became .md files)
-    KNOWLEDGE_ITEMS="$KI_OTHER_ITEMS"
-    if [[ "$KI_TEXT_EXPORTED" -gt 0 ]]; then
-      _log "  Migrated ${KI_TEXT_EXPORTED} KnowledgeText item(s) to data/ .md files (AgentMemory path)"
-    fi
   fi
 else
   _log "Skipping knowledge items (use --include-knowledge-items to include)"
@@ -814,6 +788,26 @@ else
   _log "Skipping repo instructions (use --include-repo-instructions to include)"
 fi
 
+# Session Insights (data-plane — learned patterns from past sessions)
+_log "Reading session insights..."
+RAW_SESSION_INSIGHTS=$(dp_get "/api/v1/threads/insights?skip=0&take=1000")
+if [[ "$RAW_SESSION_INSIGHTS" != "null" ]]; then
+  SESSION_INSIGHTS=$(echo "$RAW_SESSION_INSIGHTS" | jq -c '[(.insights // [])[] | {
+    id: .id,
+    threadId: .threadId,
+    title: .title,
+    generatedTimestamp: .generatedTimestamp,
+    insightMarkdown: .insightMarkdown,
+    feedbackCount: (.feedbackCount // 0),
+    positiveFeedbackCount: (.positiveFeedbackCount // 0),
+    negativeFeedbackCount: (.negativeFeedbackCount // 0)
+  }]' 2>/dev/null || echo "[]")
+else
+  SESSION_INSIGHTS="[]"
+fi
+SESSION_INSIGHT_COUNT=$(echo "$SESSION_INSIGHTS" | jq 'length')
+_log "  Found ${SESSION_INSIGHT_COUNT} session insight(s)"
+
 echo
 
 # ────────────────────── Phase 4: Dry-run summary ──────────────────────
@@ -848,6 +842,7 @@ echo "  Webhook bridge:     $([[ "$BRIDGE_EXISTS" == true ]] && echo "yes" || ec
 echo "  Incident platforms: ${INCIDENT_PLATFORM_COUNT}"
 echo "  Scheduled tasks:    ${TASK_COUNT}"
 echo "  Incident filters:   ${FILTER_COUNT}"
+echo "  Session insights:   ${SESSION_INSIGHT_COUNT}"
 
 if [[ "$DRY_RUN" == "true" ]]; then
   echo
@@ -1400,7 +1395,7 @@ if [[ $(echo "$PLUGIN_INSTALLATIONS" | jq 'length') -gt 0 ]]; then
   done
 fi
 
-# ═══════ 4. data/ — knowledge, memories, repo instructions ═══════
+# ═══════ 4. data/ — knowledge, memories, repo instructions, session insights ═══════
 
 _info "Writing data/ files"
 
@@ -1411,6 +1406,26 @@ mkdir -p "${DATA_DIR}/knowledge"
 mkdir -p "${DATA_DIR}/synthesized-knowledge"
 touch "${DATA_DIR}/knowledge/.gitkeep"
 touch "${DATA_DIR}/synthesized-knowledge/.gitkeep"
+
+# Session insights → individual .md files + metadata YAML
+if [[ "$SESSION_INSIGHT_COUNT" -gt 0 ]]; then
+  SI_DIR="${DATA_DIR}/session-insights"
+  mkdir -p "$SI_DIR"
+  for i in $(seq 0 $((SESSION_INSIGHT_COUNT - 1))); do
+    si_id=$(echo "$SESSION_INSIGHTS" | jq -r --argjson i "$i" '.[$i].id')
+    si_title=$(echo "$SESSION_INSIGHTS" | jq -r --argjson i "$i" '.[$i].title')
+    # Sanitize title for filename
+    si_fname=$(echo "$si_title" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | head -c 80)
+    [[ -z "$si_fname" ]] && si_fname="$si_id"
+    # Write insight markdown content
+    si_md=$(echo "$SESSION_INSIGHTS" | jq -r --argjson i "$i" '.[$i].insightMarkdown // ""')
+    [[ -n "$si_md" ]] && printf '%s' "$si_md" > "${SI_DIR}/${si_fname}.md"
+    # Write metadata YAML (without the large markdown blob)
+    echo "$SESSION_INSIGHTS" | jq --argjson i "$i" '.[$i] | del(.insightMarkdown) | . + {insightMarkdown: ("session-insights/" + $fname + ".md")}' \
+      --arg fname "$si_fname" | json2yaml > "${SI_DIR}/${si_fname}.yaml"
+  done
+  _log "  session-insights: ${SESSION_INSIGHT_COUNT} file(s)"
+fi
 
 if [[ $(echo "$KNOWLEDGE" | jq 'length') -gt 0 ]]; then
   mkdir -p "${DATA_DIR}"

--- a/sreagent-templates/bin/ps/Export-Agent.ps1
+++ b/sreagent-templates/bin/ps/Export-Agent.ps1
@@ -806,7 +806,7 @@ if ($INCLUDE_KNOWLEDGE) {
     _log 'Skipping AgentMemory documents (use -IncludeAll to include)'
 }
 
-# 2. Knowledge items (via connectors API)
+# 2. Knowledge items (via connectors API) — preserved as knowledgeItems for data-plane deploy
 if ($INCLUDE_KNOWLEDGE_ITEMS) {
     _log 'Reading knowledge items from connectors API...'
     $RAW_KNOWLEDGE_ITEMS = Invoke-DpGet '/api/v2/extendedAgent/connectors'
@@ -816,11 +816,11 @@ if ($INCLUDE_KNOWLEDGE_ITEMS) {
             select(.properties.dataConnectorType // "" | test("^Knowledge")) |
             {
                 name: .name,
-                type: .properties.dataConnectorType,
-                displayName: (.properties.displayName // .name),
+                type: (.type // "KnowledgeItem"),
+                dataConnectorType: .properties.dataConnectorType,
+                displayName: (.properties.displayName // .properties.extendedProperties.displayName // .name),
                 sourceUrl: (.properties.sourceUrl // ""),
-                metadata: (.properties.metadata // {}),
-                fileSize: (.properties.fileSize // 0)
+                properties: .properties
             }
         ]'
         if (-not $KNOWLEDGE_ITEMS) { $KNOWLEDGE_ITEMS = '[]' }
@@ -828,49 +828,27 @@ if ($INCLUDE_KNOWLEDGE_ITEMS) {
     $KI_COUNT = ($KNOWLEDGE_ITEMS | jq 'length') -as [int]
     _log "  Found ${KI_COUNT} knowledge item(s)"
 
-    # Download knowledge item content; KnowledgeText → .md in data/ (AgentMemory path on redeploy)
+    # Download content for knowledge items if requested
     if ($DOWNLOAD_FILES -and $KI_COUNT -gt 0) {
         _log '  Downloading knowledge item content...'
         $KI_DIR = Join-Path $FILES_DIR 'knowledge-items'
         if (-not (Test-Path $KI_DIR)) { New-Item -ItemType Directory -Path $KI_DIR -Force | Out-Null }
-        $KI_TEXT_EXPORTED = 0
-        $KI_OTHER_ITEMS = '[]'
         for ($i = 0; $i -lt $KI_COUNT; $i++) {
             $kiname = $KNOWLEDGE_ITEMS | jq -r --argjson i $i '.[$i].name'
-            $kitype = $KNOWLEDGE_ITEMS | jq -r --argjson i $i '.[$i].type'
+            $kitype = $KNOWLEDGE_ITEMS | jq -r --argjson i $i '.[$i].dataConnectorType'
             $encodedName = [System.Uri]::EscapeDataString($kiname)
-            if ($kitype -eq 'KnowledgeText') {
-                # Export as .md file in data/ → will be uploaded via AgentMemory on redeploy
-                $fname = "${kiname}.md"
-                if ($kiname -match '-md$') { $fname = ($kiname -replace '-md$', '') + '.md' }
-                $ok = Invoke-DpDownload "/api/v2/extendedAgent/connectors/${encodedName}/content" (Join-Path $KI_DIR $fname)
-                if ($ok) {
-                    _log "    + ${kiname} -> data/${fname} (will use AgentMemory on redeploy)"
-                    $KI_TEXT_EXPORTED++
-                } else {
-                    _log "    x ${kiname} (could not download content)"
-                }
-            } else {
-                # Non-text items (WebPage, File, Repository) stay as knowledgeItems
-                $ext = switch ($kitype) {
-                    'KnowledgeWebPage' { '.html' }
-                    'KnowledgeFile'    { '' }
-                    default            { '.json' }
-                }
-                $ok = Invoke-DpDownload "/api/v2/extendedAgent/connectors/${encodedName}/content" (Join-Path $KI_DIR "${kiname}${ext}")
-                if ($ok) {
-                    _log "    + ${kiname} (${kitype})"
-                } else {
-                    _log "    x ${kiname} (could not download content)"
-                }
-                $KI_OTHER_ITEMS = $KI_OTHER_ITEMS | Invoke-Jq -Compact -Filter '. + [$item + {localPath: ($dir + "/" + $item.name + $ext)}]' `
-                    -ExtraArgs @('--argjson', 'item', ($KNOWLEDGE_ITEMS | jq --argjson i $i '.[$i]'), '--arg', 'dir', $KI_DIR, '--arg', 'ext', $ext)
+            $ext = switch ($kitype) {
+                'KnowledgeText'    { '.md' }
+                'KnowledgeWebPage' { '.html' }
+                'KnowledgeFile'    { '' }
+                default            { '.json' }
             }
-        }
-        # Only keep non-text items in KNOWLEDGE_ITEMS (text ones became .md files)
-        $KNOWLEDGE_ITEMS = $KI_OTHER_ITEMS
-        if ($KI_TEXT_EXPORTED -gt 0) {
-            _log "  Migrated ${KI_TEXT_EXPORTED} KnowledgeText item(s) to data/ .md files (AgentMemory path)"
+            $ok = Invoke-DpDownload "/api/v2/extendedAgent/connectors/${encodedName}/content" (Join-Path $KI_DIR "${kiname}${ext}")
+            if ($ok) {
+                _log "    + ${kiname} (${kitype})"
+            } else {
+                _log "    x ${kiname} (could not download content)"
+            }
         }
     }
 } else {
@@ -961,6 +939,27 @@ if ($INCLUDE_REPO_INSTRUCTIONS -and $REPO_COUNT -gt 0) {
     _log 'Skipping repo instructions (use -IncludeRepoInstructions to include)'
 }
 
+# Session Insights (data-plane — learned patterns from past sessions)
+_log 'Reading session insights...'
+$RAW_SESSION_INSIGHTS = Invoke-DpGet '/api/v1/threads/insights?skip=0&take=1000'
+if ($RAW_SESSION_INSIGHTS -ne 'null') {
+    $SESSION_INSIGHTS = $RAW_SESSION_INSIGHTS | Invoke-Jq -Compact -Filter '[(.insights // [])[] | {
+        id: .id,
+        threadId: .threadId,
+        title: .title,
+        generatedTimestamp: .generatedTimestamp,
+        insightMarkdown: .insightMarkdown,
+        feedbackCount: (.feedbackCount // 0),
+        positiveFeedbackCount: (.positiveFeedbackCount // 0),
+        negativeFeedbackCount: (.negativeFeedbackCount // 0)
+    }]'
+    if (-not $SESSION_INSIGHTS) { $SESSION_INSIGHTS = '[]' }
+} else {
+    $SESSION_INSIGHTS = '[]'
+}
+$SESSION_INSIGHT_COUNT = ($SESSION_INSIGHTS | jq 'length') -as [int]
+_log "  Found ${SESSION_INSIGHT_COUNT} session insight(s)"
+
 Write-Host ''
 
 # ═══════════════════════════════════════════════════════════════════
@@ -998,6 +997,7 @@ Write-Host "  Webhook bridge:     $(if ($BRIDGE_EXISTS) { 'yes' } else { 'no' })
 Write-Host "  Incident platforms: ${INCIDENT_PLATFORM_COUNT}"
 Write-Host "  Scheduled tasks:    ${TASK_COUNT}"
 Write-Host "  Incident filters:   ${FILTER_COUNT}"
+Write-Host "  Session insights:   ${SESSION_INSIGHT_COUNT}"
 
 if ($DryRun) {
     Write-Host ''
@@ -1542,7 +1542,7 @@ if ($piCount -gt 0) {
     }
 }
 
-# ═══════ 4. data/ — knowledge, memories, repo instructions ═══════
+# ═══════ 4. data/ — knowledge, memories, repo instructions, session insights ═══════
 
 _info 'Writing data/ files'
 
@@ -1552,6 +1552,29 @@ foreach ($subDir in @('knowledge', 'synthesized-knowledge')) {
     if (-not (Test-Path $p)) { New-Item -ItemType Directory -Path $p -Force | Out-Null }
     $gitkeep = Join-Path $p '.gitkeep'
     if (-not (Test-Path $gitkeep)) { '' | Set-Content $gitkeep }
+}
+
+# Session insights → individual .md files + metadata YAML
+if ($SESSION_INSIGHT_COUNT -gt 0) {
+    $siDir = Join-Path $DATA_DIR 'session-insights'
+    if (-not (Test-Path $siDir)) { New-Item -ItemType Directory -Path $siDir -Force | Out-Null }
+    for ($i = 0; $i -lt $SESSION_INSIGHT_COUNT; $i++) {
+        $siId = $SESSION_INSIGHTS | jq -r --argjson i $i '.[$i].id'
+        $siTitle = $SESSION_INSIGHTS | jq -r --argjson i $i '.[$i].title'
+        # Sanitize title for filename
+        $siFname = ($siTitle -replace '[^a-zA-Z0-9]', '-' -replace '-+', '-' -replace '^-|-$', '').ToLower()
+        if ($siFname.Length -gt 80) { $siFname = $siFname.Substring(0, 80) }
+        if (-not $siFname) { $siFname = $siId }
+        # Write insight markdown content
+        $siMd = $SESSION_INSIGHTS | Invoke-Jq -Raw -Filter '.[$i].insightMarkdown // ""' -ExtraArgs @('--argjson', 'i', "$i")
+        if ($siMd) {
+            [System.IO.File]::WriteAllText((Join-Path $siDir "${siFname}.md"), $siMd)
+        }
+        # Write metadata YAML (without the large markdown blob)
+        $SESSION_INSIGHTS | Invoke-Jq -Filter '.[$i] | del(.insightMarkdown) | . + {insightMarkdown: ("session-insights/" + $fname + ".md")}' -ExtraArgs @('--argjson', 'i', "$i", '--arg', 'fname', $siFname) |
+            ConvertTo-Yaml | Set-Content -Path (Join-Path $siDir "${siFname}.yaml") -NoNewline -Encoding utf8
+    }
+    _log "  session-insights: ${SESSION_INSIGHT_COUNT} file(s)"
 }
 
 $knowledgeCount = ($KNOWLEDGE | jq 'length') -as [int]
@@ -1588,21 +1611,13 @@ if ($DOWNLOAD_FILES -and (Test-Path $FILES_DIR)) {
             Copy-Item -Path (Join-Path $srcDir '*') -Destination $destDir -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
-    # KnowledgeText .md files go to data/ root so assemble auto-discovers them
-    # for AgentMemory upload (not back into knowledge-items which creates ARM connectors)
+    # Knowledge items stay in knowledge-items/ for data-plane connector PUT on redeploy
     $kiSrcDir = Join-Path $FILES_DIR 'knowledge-items'
     if (Test-Path $kiSrcDir) {
-        foreach ($f in Get-ChildItem -Path $kiSrcDir -Filter '*.md' -File -ErrorAction SilentlyContinue) {
-            Copy-Item $f.FullName (Join-Path $DATA_DIR $f.Name) -Force
-        }
-        # Non-.md files (WebPage, File) stay in knowledge-items/
-        $nonMdFiles = Get-ChildItem -Path $kiSrcDir -File -ErrorAction SilentlyContinue | Where-Object { $_.Extension -ne '.md' }
-        if ($nonMdFiles) {
-            $kiDestDir = Join-Path $DATA_DIR 'knowledge-items'
-            if (-not (Test-Path $kiDestDir)) { New-Item -ItemType Directory -Path $kiDestDir -Force | Out-Null }
-            foreach ($f in $nonMdFiles) {
-                Copy-Item $f.FullName (Join-Path $kiDestDir $f.Name) -Force
-            }
+        $kiDestDir = Join-Path $DATA_DIR 'knowledge-items'
+        if (-not (Test-Path $kiDestDir)) { New-Item -ItemType Directory -Path $kiDestDir -Force | Out-Null }
+        foreach ($f in Get-ChildItem -Path $kiSrcDir -File -ErrorAction SilentlyContinue) {
+            Copy-Item $f.FullName (Join-Path $kiDestDir $f.Name) -Force
         }
     }
     if ($FILES_DIR -ne $DATA_DIR -and $FILES_DIR -ne (Join-Path $EXPORT_DIR 'data')) {


### PR DESCRIPTION
## Changes

### 1. Knowledge items: ARM → data-plane deployment path

Knowledge items (KnowledgeFile/KnowledgeText/KnowledgeWebPage) were deployed via ARM `PUT /connectors/{name}`, causing them to appear on the Connectors page with stuck "Connecting" status instead of Knowledge Sources.

**Fix:** PUT to data-plane `/api/v2/extendedAgent/connectors/{name}` with `type: "KnowledgeItem"`.

### 2. Assemble: .md files routed to knowledgeItems (not AgentMemory)

`.md` files in `data/`, `data/knowledge/`, and `data/session-insights/` were going into the `knowledge` array (AgentMemory upload). Now they go into `knowledgeItems` (data-plane connector PUT) so they appear under Knowledge Sources.

Also removed `KnowledgeFile` from the extras `connectors` array (was causing double-deploy as ARM connector).

### 3. Export: preserve knowledge items as-is

Stopped converting KnowledgeText items to `.md` files for AgentMemory re-upload. They are now preserved with full `properties` for round-trip via the connector PUT path.

### 4. Session insights: export + deploy support

- **Export:** reads from `GET /api/v1/threads/insights` → writes to `data/session-insights/*.md` + `.yaml`
- **Deploy/Clone:** `data/session-insights/*.md` auto-discovered by assemble → deployed as knowledge items (no write API exists for session insights, so they transfer as searchable knowledge)

## Files changed (all sh + ps1 pairs)

| Script | .sh | .ps1 |
|---|---|---|
| export-agent | ✓ | ✓ |
| apply-extras | ✓ | ✓ |
| assemble-agent | ✓ | ✓ |

## Testing

- All 6 scripts pass syntax validation
- Tested new-agent + deploy with knowledge files → deployed as KnowledgeItem connectors, indexed in Knowledge Sources
- Tested export on demo1-dt-snow → session insights exported, knowledge items metadata captured
- Assemble routes .md files → knowledge: 0, items: 2

Supersedes #283.