### PR TITLE
Fix starter lab SRE response plan creationModify response plan creation parameters in post-provision.sh

### DIFF
--- a/labs/starter-lab/scripts/post-provision.sh
+++ b/labs/starter-lab/scripts/post-provision.sh
@@ -365,11 +365,11 @@ API_VERSION="2025-05-01-preview"
 FILTER_CREATED=false
 for attempt in 1 2 3 4 5; do
   TOKEN=$(get_token)
-  HTTP_CODE=$(curl -s -o ${TEMP_DIR}/response-plan-resp.txt -w "%{http_code}" \
+  HTTP_CODE=$(curl -s -o "${TEMP_DIR}/response-plan-resp.txt" -w "%{http_code}" \
     -X PUT "${AGENT_ENDPOINT}/api/v1/incidentPlayground/filters/grubify-http-errors" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \
-    --data-binary '{"id":"grubify-http-errors","name":"Grubify HTTP Errors","priorities":["Sev0","Sev1","Sev2","Sev3","Sev4"],"titleContains":"","handlingAgent":"incident-handler","agentMode":"autonomous","maxAttempts":3}')
+    --data-binary '{"id":"grubify-http-errors","name":"Grubify HTTP Errors","priorities":["Sev0","Sev1","Sev2","Sev3","Sev4"],"titleContains":"alert-http-5xx-sre-lab","titleContainsAll":[],"titleContainsAny":[],"titleNotContains":[],"handlingAgent":"incident-handler","agentMode":"autonomous","maxAutomatedInvestigationAttempts":3,"mergeEnabled":true,"mergeWindowHours":3,"isEnabled":true}')
 
   if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "202" ] || [ "$HTTP_CODE" = "409" ]; then
     echo "   ✅ Response plan → incident-handler"
@@ -383,6 +383,7 @@ done
 
   if [ "$FILTER_CREATED" = "false" ]; then
     echo "   ⚠️  Response plan failed after 5 attempts (set up in portal or run: ./scripts/post-provision.sh --retry)"
+    echo "   API response: $(cat "${TEMP_DIR}/response-plan-resp.txt")"
   fi
   rm -f ${TEMP_DIR}/response-plan-resp.txt
 


### PR DESCRIPTION
## Summary

Fixes response plan creation in the starter lab post-provision script.

## Problem

The script repeatedly received HTTP 400 when creating the `grubify-http-errors` response plan. Azure Monitor was connected and alerts fired successfully, but no response plan existed, so alerts were not routed to the SRE agent.

## Changes

- Replace obsolete `maxAttempts` with `maxAutomatedInvestigationAttempts`
- Add the response plan fields required by the current API
- Scope the plan to `alert-http-5xx-sre-lab`
- Print the API response body when creation fails
- Quote temporary file paths

## Evidence

Before:
- Response plan PUT returned HTTP 400
- SRE Agent response-plan API returned `[]`
- Azure Monitor alerts fired but were not routed to the agent

After:
- Response plan PUT returned HTTP 200
- `bash scripts/post-provision.sh --retry` completed successfully
- The `grubify-http-errors` plan was created and routed to `incident-handler`