### PR TITLE
Update Azure CLI version check method

### DIFF
--- a/labs/zava-learning/scripts/check-environment.ps1
+++ b/labs/zava-learning/scripts/check-environment.ps1
@@ -10,7 +10,7 @@ function Check($name, $cmd) {
   else { Write-Host "  ✗ $name (missing)" -ForegroundColor Red; $script:ok = $false }
 }
 Write-Host "Zava Learning — environment check" -ForegroundColor Cyan
-Check "Azure CLI"        { az version --query '"azure-cli"' -o tsv }
+Check "Azure CLI"        { az version | ConvertFrom-Json | Select-Object -ExpandProperty 'azure-cli' }
 Check "Bicep"            { az bicep version }
 Check "Azure Developer CLI (azd)" { azd version }
 Check "PowerShell 7+ (pwsh)" { pwsh -v }


### PR DESCRIPTION
This method is compatible when not only running PowerShell in BASH, but also from CMD in Windows.

Found that line 13 in this PowerShell script was not compatible with PowerShell (7.6.5) running on Windows, but it was compatible with running PowerShell running in BASH.  Bypassing the use of querying JMESPath with PowerShell native cmdlets offers greater cross-platform compatibility.