### PR TITLE
Fix PAGERDUTY_API_TOKEN description in .env.sample

### DIFF
--- a/labs/zava-learning/sre-config/.env.sample
+++ b/labs/zava-learning/sre-config/.env.sample
@@ -5,8 +5,8 @@
 # "Microsoft Azure" integration URL — used by the Azure Monitor action group to
 # CREATE incidents (Azure -> PagerDuty). Wired via the pagerDutyWebhookUrl param.
 PAGERDUTY_WEBHOOK_URL=https://events.pagerduty.com/integration/<integration-key>/enqueue
-# REST API token (General Access, read/write) — lets the agent ack/annotate/resolve
-# incidents (agent -> PagerDuty). PagerDuty > Integrations > API Access Keys.
+# REST API token — lets the agent ack/annotate/resolve incidents (agent -> PagerDuty).
+# Create one via PagerDuty > profile icon > My Profile > User Settings > API Access > Create API User Key.
 PAGERDUTY_API_TOKEN=
 # Your PagerDuty subdomain, e.g. zava-learning  (zava-learning.pagerduty.com)
 PAGERDUTY_SUBDOMAIN=


### PR DESCRIPTION
The instruction about how to obtain an API token for PagerDuty written in .env.sample is not correct. This PR simply updates the instruction. This will reduce a chance of users getting confused.